### PR TITLE
Fix Critical KW issue:Buffer Overflow

### DIFF
--- a/bluetooth/h4_protocol.cc
+++ b/bluetooth/h4_protocol.cc
@@ -181,7 +181,8 @@ void H4Protocol::GetUsbpath(void) {
         vid = descriptor.idVendor;
         pid = descriptor.idProduct;
         if (H4Protocol::IsIntelController(vid, pid)) {
-            sprintf(dev_address, "/dev/bus/usb/%03d/%03d", busnum, devnum);
+            snprintf(dev_address, sizeof(dev_address), "/dev/bus/usb/%03d/%03d",
+                                                       busnum, devnum);
             ALOGV("Value of BT device address = %s", dev_address);
             goto exit;
         }


### PR DESCRIPTION
sprintf does not check the buffer boundaries, and hence it create
KWerrors. Change the sprintf to snprintf

Tracked-On: OAM-80092
Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>