### PR TITLE
Fix for Klocwork issue in Connectivity-BT domain

### DIFF
--- a/bluetooth/h4_protocol.cc
+++ b/bluetooth/h4_protocol.cc
@@ -169,8 +169,7 @@ void H4Protocol::GetUsbpath(void) {
     count = libusb_get_device_list(ctx, &dev_list);
     if (count <= 0) {
         ALOGE("Error getting USB device list: %s\n", strerror(count));
-        libusb_exit(ctx);
-        return;
+        goto exit;
     }
     for (i = 0; i < count; ++i) {
         struct libusb_device* dev = dev_list[i];


### PR DESCRIPTION
Fix for Possible memory leak - Dynamic memory stored in 'dev_list'
allocated through function 'libusb_get_device_list' is not freed
when the value of count <= 0

Tracked-On: OAM-81025
Signed-off-by: Amrita Raju <amrita.raju@intel.com>


@JeevakaPrabu @swaroopbalan @sgnanase 