### PR TITLE
NN_GPU_HAL: fix klockwork error issue by initializing activation as 0

### DIFF
--- a/nn_gpu/gles/gles_cs_program_key.h
+++ b/nn_gpu/gles/gles_cs_program_key.h
@@ -33,7 +33,7 @@ struct GlesCsProgramKeyBasic
         opType = type;
     }
     OperationType opType;
-    int32_t activation;
+    int32_t activation = {0};
     uint32_t localSizeX;
     uint32_t localSizeY;
     uint32_t localSizeZ;


### PR DESCRIPTION
Tracked-On: OAM-83232
Signed-off-by: Fei Jiang <fei.jiang@intel.com>