### PR TITLE
Fix Kw issue

### DIFF
--- a/nn_gpu/gles/gles_cs_executor.cpp
+++ b/nn_gpu/gles/gles_cs_executor.cpp
@@ -179,6 +179,8 @@ void GlesCsExecutor::showOperationTimers()
         }
         sum += avg;
     }
+    if (sum == 0.0)
+        return;
 
     std::sort(operationTimers.begin(), operationTimers.end(), OperationCpuTimer::sort);
 


### PR DESCRIPTION
Add a zero check to pass klocwork scan. Normally model.operations.size() is not 0.
If it is 0, will not use GPU for NN GPU computing, so direct return here is not harmful.

Tracked-On: OAM-90460
Signed-off-By: Liu, Yuanzhe <yuanzhe.liu@intel.com>