### PR TITLE
health HAL: Add changes for battery level indicator

### DIFF
--- a/health/HealthService.cpp
+++ b/health/HealthService.cpp
@@ -20,6 +20,7 @@
 #include <health2/Health.h>
 #include <health2/service.h>
 #include <health2/powerSupplyType.h>
+#include <health2/battery_notifypkt.h>
 #include <hidl/HidlTransportSupport.h>
 
 #include <utils/String8.h>
@@ -34,14 +35,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-
 using android::hardware::health::V1_0::BatteryStatus;
 using android::hardware::health::V1_0::BatteryHealth;
 using namespace android;
 
 #define POWER_SUPPLY_SUBSYSTEM "power_supply"
 #define POWER_SUPPLY_SYSFS_PATH "/sys/class/" POWER_SUPPLY_SUBSYSTEM
-
 
 unsigned int platformPowerSupplyType = BATTERY;
 
@@ -73,7 +72,8 @@ void healthd_board_init(struct healthd_config*)
 
 int healthd_board_battery_update(struct android::BatteryProperties *props)
 {
-
+    if (get_battery_properties(props))
+        platformPowerSupplyType = BATTERY;
     if (platformPowerSupplyType == CONSTANT_POWER) {
         props->batteryStatus = android::BATTERY_STATUS_FULL;
         props->batteryHealth = android::BATTERY_HEALTH_GOOD;
@@ -93,7 +93,6 @@ int healthd_board_battery_update(struct android::BatteryProperties *props)
         UNUSED(props);
     return 0;
 }
-
 
 int main(void) {
     return health_service_main();

--- a/health/include/health2/battery_notifypkt.h
+++ b/health/include/health2/battery_notifypkt.h
@@ -1,0 +1,58 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <healthd/BatteryMonitor.h>
+
+#define BASE_PATH "/sys/class/power_supply/test_battery/"
+#define INTELIPCID "INTELIPC"
+
+using namespace android;
+
+bool get_battery_properties(android::BatteryProperties *props);
+
+struct header {
+    uint8_t intelipc[8];
+    uint16_t notify_id;
+    uint16_t length;
+};
+
+struct initial_pkt {
+    uint8_t model_name[28];
+    uint8_t serial_number[52];
+    uint8_t manufacturer[24];
+    uint8_t technology[8];
+    uint8_t type[8];
+    uint8_t present[4];
+};
+
+struct monitor_pkt {
+    uint32_t capacity;
+    uint32_t charge_full_design;
+    uint32_t temp;
+    uint32_t charge_now;
+    uint32_t time_to_empty_avg;
+    uint32_t charge_full;
+    uint32_t time_to_full_now;
+    uint32_t voltage_now;
+    uint8_t charge_type[12];
+    uint8_t capacity_level[12];
+    uint8_t status[12];
+    uint8_t health[24];
+};
+
+/* TODO Below structure is not getting used in this version of code.
+ * Next version will be using this.
+ *
+ * Size of the variable is same as passed on the network buffer.
+ * So any change in handling the below structure will not break
+ * the client code.
+ */
+struct battery_sysfs {
+    uint8_t intelipc[8];
+    uint8_t noftify_id[2];
+    uint8_t length[2];
+    
+    union   {
+        struct initial_pkt initpkt;
+        struct monitor_pkt monitorpkt;
+    };
+};


### PR DESCRIPTION
This patch adds changes for health HAL to communicate
with host battery utility to fetch battery info via
vsock.

Tracked-On: OAM-90939
Signed-off-by: Saranya Gopal <saranya.gopal@intel.com>