### PR TITLE
EM: Update intelipc id field size

### DIFF
--- a/health/include/health2/battery_notifypkt.h
+++ b/health/include/health2/battery_notifypkt.h
@@ -10,7 +10,7 @@ using namespace android;
 bool get_battery_properties(android::BatteryProperties *props);
 
 struct header {
-    uint8_t intelipc[8];
+    uint8_t intelipc[9];
     uint16_t notify_id;
     uint16_t length;
 };

--- a/thermal/Thermal.cpp
+++ b/thermal/Thermal.cpp
@@ -55,7 +55,7 @@ struct zone_info {
 };
 
 struct header {
-	uint8_t intelipcid[8];
+	uint8_t intelipcid[9];
 	uint16_t notifyid;
 	uint16_t length;
 };


### PR DESCRIPTION
This patch updates intelipc ID field size in thermal
and health HALs to match with the host utilities.

Tracked-On: OAM-91350
Signed-off-by: Saranya Gopal <saranya.gopal@intel.com>