### PR TITLE
EM: Update port numbers to avoid conflict with other domains

### DIFF
--- a/health/healthd_common.cpp
+++ b/health/healthd_common.cpp
@@ -40,7 +40,7 @@
 #include <health2/Health.h>
 #include <health2/battery_notifypkt.h>
 
-#define HEALTH_PORT 1234
+#define HEALTH_PORT 14196
 
 using namespace android;
 

--- a/thermal/Thermal.cpp
+++ b/thermal/Thermal.cpp
@@ -30,7 +30,7 @@
 #define CPU_USAGE_FILE              "/proc/stat"
 #define CPU_ONLINE_FILE             "/sys/devices/system/cpu/online"
 #define TEMP_UNIT                   1000
-#define THERMAL_PORT                1235
+#define THERMAL_PORT                14096
 #define MAX_ZONES                   40
 
 namespace android {


### PR DESCRIPTION
This patch updates the port numbers used by virtual sockets
so that they don't conflict with other domains.

Tracked-On: OAM-91429
Signed-off-by: Saranya Gopal <saranya.gopal@intel.com>