### PR TITLE
Thermal: Fix few minor issues

### DIFF
--- a/thermal/Thermal.cpp
+++ b/thermal/Thermal.cpp
@@ -29,7 +29,7 @@
 #define CPU_USAGE_PARAS_NUM         5
 #define CPU_USAGE_FILE              "/proc/stat"
 #define CPU_ONLINE_FILE             "/sys/devices/system/cpu/online"
-#define TEMP_UNIT                   1000
+#define TEMP_UNIT                   1000.0
 #define THERMAL_PORT                14096
 #define MAX_ZONES                   40
 
@@ -51,7 +51,7 @@ struct zone_info {
 	uint32_t trip_1;
 	uint32_t trip_2;
 	uint16_t number;
-	uint16_t type;
+	int16_t type;
 };
 
 struct header {
@@ -149,7 +149,7 @@ static bool is_vsock_present;
 
 
 struct temp_info {
-    uint16_t type;
+    int16_t type;
     uint32_t temp;
 };
 


### PR DESCRIPTION
This patch changes TEMP_UNIT to 1000.0 to
prevent truncation during integer division.
This also changes the data type of 'type'
variable as int16_t so that it can take '-1'
as value since as per AOSP, unknown temperature
type should be -1.

Tracked-On: OAM-90936
Signed-off-by: Saranya Gopal <saranya.gopal@intel.com>