### PR TITLE
Batteryless behavior changes for CIV

### DIFF
--- a/health/2.0/HealthService.cpp
+++ b/health/2.0/HealthService.cpp
@@ -75,9 +75,9 @@ int healthd_board_battery_update(struct android::BatteryProperties *props)
     if (get_battery_properties(props))
         platformPowerSupplyType = BATTERY;
     if (platformPowerSupplyType == CONSTANT_POWER) {
-        props->batteryStatus = android::BATTERY_STATUS_FULL;
-        props->batteryHealth = android::BATTERY_HEALTH_GOOD;
-        props->batteryLevel = 100;
+        props->batteryStatus = android::BATTERY_STATUS_UNKNOWN;
+        props->batteryHealth = android::BATTERY_HEALTH_UNKNOWN;
+        props->batteryLevel = 0;
         props->batteryChargeCounter= 1000000;
         props->batteryCurrent= 1000000;
         props->chargerAcOnline = true;
@@ -85,7 +85,7 @@ int healthd_board_battery_update(struct android::BatteryProperties *props)
         props->chargerWirelessOnline = false;
         props->maxChargingCurrent= 2500000;
         props->maxChargingVoltage= 4300000;
-        props->batteryPresent= true;
+        props->batteryPresent= false;
         props->batteryVoltage= 1200000;
         props->batteryTemperature= 25;
         props->batteryFullCharge= 4200000;


### PR DESCRIPTION
when Android does not detect a battery device for CIV mode
battery-related default values are required to update
according to the Android 9 release or above

Change-Id: Ic7c48c0e983e65421ecdc2d913fa7d1fc1e99ba0
Tracked-On: OAM-95379
Signed-off-by: jayanth1 <shankar.srinivas.jayanthi@intel.com>
Signed-off-by: Kishan Mochi <kishan.mochi@intel.com>