### PR TITLE
hal:health: suspend of android fails due to frequent wake up alarm.

### DIFF
--- a/health/2.1/libhealthd/healthd_board_default.cpp
+++ b/health/2.1/libhealthd/healthd_board_default.cpp
@@ -157,8 +157,8 @@ exit:
 
 void healthd_board_init(struct healthd_config *config)
 {
-    config->periodic_chores_interval_fast = 1;
-    config->periodic_chores_interval_slow = 1;
+    config->periodic_chores_interval_fast = 60;
+    config->periodic_chores_interval_slow = 60*10;
 
     
     vsock_thread = std::thread(recv_vsock);

--- a/health/2.1/utils/libhealthloop/HealthLoop.cpp
+++ b/health/2.1/utils/libhealthloop/HealthLoop.cpp
@@ -240,8 +240,8 @@ int HealthLoop::InitInternal() {
     // Note that healthd_config_ is initialized before wakealarm_fd_; see
     // AdjustUeventWakealarmPeriods().
     Init(&healthd_config_);
-    healthd_config_.periodic_chores_interval_fast = 1;
-    healthd_config_.periodic_chores_interval_fast = 1; 
+    healthd_config_.periodic_chores_interval_fast = 60;
+    healthd_config_.periodic_chores_interval_slow = 60*10; 
     WakeAlarmInit();
     UeventInit();
 


### PR DESCRIPTION
There is  a suspend failure due frequent wake up alarm
set by ealth hal. Health hal polling interval is one second
second. Due to this The Alramtimer suspend failed when nearest
alarm wakeup time is less than 2 sec and thereafter it cancels
the complete system suspend operation. Modify the poll interval
to 60 seconds as per goole specs.

Tracked-On:

Signed-off-by: Kaushlendra Kumar <kaushalendra.kumar@intel.com>