### PR TITLE
Change battery properties as per batteryless device requirement

### DIFF
--- a/health/2.1/HealthImpl.cpp
+++ b/health/2.1/HealthImpl.cpp
@@ -58,6 +58,9 @@ void HealthImpl::UpdateHealthInfo(HealthInfo* health_info) {
     convertFromHealthInfo(health_info->legacy.legacy, &props);
     healthd_board_battery_update(&props);
     convertToHealthInfo(&props, health_info->legacy.legacy);
+    health_info->batteryCapacityLevel = android::hardware::health::V2_1::BatteryCapacityLevel::UNKNOWN;
+    health_info->batteryChargeTimeToFullNowSeconds = 0;
+    health_info->batteryFullChargeDesignCapacityUah = 0;
 }
 
 }  // namespace implementation

--- a/health/2.1/libhealthd/healthd_board_default.cpp
+++ b/health/2.1/libhealthd/healthd_board_default.cpp
@@ -174,17 +174,8 @@ int healthd_board_battery_update(struct android::BatteryProperties *props)
 	props->batteryStatus = android::BATTERY_STATUS_UNKNOWN;
 	props->batteryHealth = android::BATTERY_HEALTH_UNKNOWN;
 	props->batteryLevel = 0;
-	props->batteryChargeCounter= 1000000;
-	props->batteryCurrent= 0;
-	props->chargerAcOnline = true;
-	props->chargerUsbOnline= false;
-	props->chargerWirelessOnline = false;
-	props->maxChargingCurrent= 2500000;
-	props->maxChargingVoltage= 4300000;
 	props->batteryPresent= false;
-	props->batteryVoltage= 1200000;
-	props->batteryTemperature= 25;
-	props->batteryFullCharge= 4200000;
+	props->chargerAcOnline = true;
     }	    
     return 0;
 }


### PR DESCRIPTION
Android 9 and higher batteryless devices should configure
battery proprties as per google. So update the properties.

Tracked-On: OAM-96466
Signed-off-by: Jaikrishna Nemallapudi <nemallapudi.jaikrishna@intel.com>