### PR TITLE
Get current CPU number dynamically Insted of hardcode CPU cores.

### DIFF
--- a/thermal/Thermal.h
+++ b/thermal/Thermal.h
@@ -76,12 +76,15 @@ class Thermal : public IThermal {
         unregisterThermalChangedCallback_cb _hidl_cb) override;
     Return<void> getCurrentCoolingDevices(bool filterType, CoolingType type,
                                           getCurrentCoolingDevices_cb _hidl_cb) override;
+    int getNumCpu(void){ return mNumCpu;};
 
    private:
     std::mutex thermal_temp_mutex;
     std::mutex thermal_callback_mutex_;
     std::vector<CallbackSetting> callbacks_;
     std::thread mCheckThread;
+    int mNumCpu;
+    int thermal_get_cpu_usages(CpuUsage *list) ;
 };
 
 }  // namespace implementation


### PR DESCRIPTION
Change-Id: I2721749c05a9b9255956a97cc751b3ff4e9edb82
Tracked-On: OAM-97437
Signed-off-by: Kant, Rohit <rohitx.kant@intel.com>