### PR TITLE
Update health HAL changes based on S

### DIFF
--- a/health/2.1/hal_conversion.h
+++ b/health/2.1/hal_conversion.h
@@ -15,7 +15,7 @@
  */
 #ifndef HARDWARE_INTERFACES_HEALTH_V1_0_DEFAULT_INCLUDE_HAL_CONVERSION_H_
 #define HARDWARE_INTERFACES_HEALTH_V1_0_DEFAULT_INCLUDE_HAL_CONVERSION_H_
-#include <android/hardware/health/1.0/IHealth.h>
+#include <android/hardware/health/1.0/types.h>
 #include <healthd/healthd.h>
 namespace android {
 namespace hardware {

--- a/health/2.1/libhealthd/Android.bp
+++ b/health/2.1/libhealthd/Android.bp
@@ -6,7 +6,7 @@ cc_library_static {
     vendor_available: true,
     recovery_available: true,
     cflags: ["-Werror"],
-    include_dirs: ["system/core/base/include"],
+    include_dirs: ["system/libbase/include"],
     header_libs: ["libhealthd_headers"],
     shared_libs: [
         "libcutils",


### PR DESCRIPTION
This patch updates the changes based on Android 12
1. system/core/base is moved to system/libbase
2. Health hal 1.0 is deprecated so IHealth.h is replaced
with types.h.

Signed-off-by: Tanuj Tekriwal <tanuj.tekriwal@intel.com>