### PR TITLE
Use CLOCK_BOOTTIME for default sensor implementation

### DIFF
--- a/sensors/2.0/iiohal_mediation_v2.0/Sensor.cpp
+++ b/sensors/2.0/iiohal_mediation_v2.0/Sensor.cpp
@@ -130,7 +130,7 @@ void Sensor::run() {
             });
         } else {
             timespec curTime;
-            clock_gettime(CLOCK_REALTIME, &curTime);
+            clock_gettime(CLOCK_BOOTTIME, &curTime);
             int64_t now = (curTime.tv_sec * kNanosecondsInSeconds) + curTime.tv_nsec;
             int64_t nextSampleTime = mLastSampleTimeNs + mSamplingPeriodNs;
 


### PR DESCRIPTION
The sensor implementation used to generate periodic signals according to
CLOCK_REALTIME. The clock can be adjusted by user or synchronization
service and results in wrong period. This commit changes it to
CLOCK_BOOTTIME which is monotonic.

Test: atest VtsHalSensorsV2_0TargetTest
Test: atest VtsHalSensorsV2_1TargetTest
Test: atest CtsSensorTestCases

Signed-off-by: vilasrk <vilas.r.k@intel.com>