### PR TITLE
[VSOCK]: Reconnect VSOCK

### DIFF
--- a/health/2.1/libhealthd/healthd_board_default.cpp
+++ b/health/2.1/libhealthd/healthd_board_default.cpp
@@ -158,6 +158,10 @@ static void recv_vsock() {
                 parse_battery_properties(mpkt);
             }
         }
+        else {
+            close(vsock_fd);
+            connect_vsock(&vsock_fd);
+        }
         sleep(1);
     }
     free(ipkt);

--- a/thermal/Thermal.cpp
+++ b/thermal/Thermal.cpp
@@ -354,7 +354,8 @@ static int recv_vsock(int *vsock_fd)
         return -ENOMEM;
     memset(msgbuf, 0, sizeof(msgbuf));
     ret = recv(*vsock_fd, msgbuf, sizeof(msgbuf), MSG_DONTWAIT);
-    if (ret < 0 && errno == EBADF) {
+    if (ret < 0 ) {
+        close(*vsock_fd);
         if (connect_vsock(vsock_fd) == 0)
             ret = recv(*vsock_fd, msgbuf, sizeof(msgbuf), MSG_DONTWAIT);
     }


### PR DESCRIPTION
Reconnect VSOCK connections in case of
connection drop due to device suspend.

Tracked-On: OAM-100107
Signed-off-by: Vilas R K <vilas.r.k@intel.com>