### PR TITLE
VSOCK Implementation for LibIIO

### DIFF
--- a/sensors/2.0/iiohal_mediation_v2.0/iioClient.h
+++ b/sensors/2.0/iiohal_mediation_v2.0/iioClient.h
@@ -41,6 +41,8 @@
 
 #define MAX_SENSOR 9
 #define MAX_CHANNEL 3
+#define SENSOR_PORT "30431"
+#define USE_VM_CONTEXT
 
 struct iio_sensor_map {
     const char *name;

--- a/sensors/2.0/iiohal_mediation_v2.0/libiio_client/iio-private.h
+++ b/sensors/2.0/iiohal_mediation_v2.0/libiio_client/iio-private.h
@@ -132,6 +132,8 @@ struct iio_backend_ops {
 
     void (*shutdown)(struct iio_context *ctx);
 
+    int (*request_client_id)(const struct iio_context *ctx);
+    int (*register_client_id)(const struct iio_device *dev);
     int (*get_version)(const struct iio_context *ctx, unsigned int *major,
             unsigned int *minor, char git_tag[8]);
 
@@ -167,6 +169,7 @@ struct iio_context {
     char **attrs;
     char **values;
     unsigned int nb_attrs;
+    int client_id;
 };
 
 struct iio_channel {
@@ -260,6 +263,7 @@ int write_double(char *buf, size_t len, double val);
 
 struct iio_context * local_create_context(void);
 struct iio_context * network_create_context(const char *hostname);
+struct iio_context * vm_create_context(unsigned int port);
 struct iio_context * xml_create_context_mem(const char *xml, size_t len);
 struct iio_context * xml_create_context(const char *xml_file);
 struct iio_context * usb_create_context(unsigned int bus, unsigned int address,
@@ -287,6 +291,7 @@ char *iio_strdup(const char *str);
 int iio_context_add_attr(struct iio_context *ctx,
         const char *key, const char *value);
 
+int get_reserve_fd();
 #undef __api
 
 #endif /* __IIO_PRIVATE_H__ */

--- a/sensors/2.0/iiohal_mediation_v2.0/libiio_client/iio.h
+++ b/sensors/2.0/iiohal_mediation_v2.0/libiio_client/iio.h
@@ -337,6 +337,14 @@ __api struct iio_context * iio_create_xml_context_mem(
  * @return On failure, NULL is returned and errno is set appropriately */
 __api struct iio_context * iio_create_network_context(const char *host);
 
+/** @brief Create a context from a VSOCK
+ * @param port The port number to a listening VSOCK
+ * @return On success, a pointer to an iio_context structure
+ * @return On failure, NULL is returned and errno is set appropriately */
+__api struct iio_context * iio_create_vm_context(const char *port);
+
+/*function declaration for reserve socket file descriptor*/
+int get_reserve_fd_context();
 
 /** @brief Create a context from a URI description
  * @param uri A URI describing the context location

--- a/sensors/2.0/iiohal_mediation_v2.0/libiio_client/iiod-client.h
+++ b/sensors/2.0/iiohal_mediation_v2.0/libiio_client/iiod-client.h
@@ -38,6 +38,7 @@ struct iiod_client * iiod_client_new(struct iio_context_pdata *pdata,
         struct iio_mutex *lock, const struct iiod_client_ops *ops);
 void iiod_client_destroy(struct iiod_client *client);
 
+int iiod_client_request_client_id(struct iiod_client *client, void *desc);
 int iiod_client_get_version(struct iiod_client *client, void *desc,
         unsigned int *major, unsigned int *minor, char *git_tag);
 int iiod_client_get_trigger(struct iiod_client *client, void *desc,
@@ -59,7 +60,9 @@ int iiod_client_open_unlocked(struct iiod_client *client, void *desc,
         const struct iio_device *dev, size_t samples_count,
         bool cyclic);
 int iiod_client_close_unlocked(struct iiod_client *client, void *desc,
-        const struct iio_device *dev);
+                const struct iio_device *dev);
+int iiod_client_register_client_id(struct iiod_client *client, void *desc,
+                int client_id);
 ssize_t iiod_client_read_unlocked(struct iiod_client *client, void *desc,
         const struct iio_device *dev, void *dst, size_t len,
         uint32_t *mask, size_t words);


### PR DESCRIPTION
libiio: network context support for UNIX domain and virtio sockets

libiio has support for a network context object, which enables connecting
to an iiod server running on a remote machine via TCP/IP.

For Chrome OS purposes, we want to run iiod over a UNIX socket or a vsock
to enable either VMs or local processes to connect and manage sensors, but
not remote devices across the network.

This patch adds support to the server and the client sides of libiio/iiod
to create UNIX domain and virtio sockets, and establish connections over
such sockets.

reference:https://chromium-review.googlesource.com/c/chromiumos/third_party/libiio/+/1719570

reconnecting vsock for sensors after suspend/resume case.

Tracked-On: OAM-102904
Signed-off-by: vilasrk <vilas.r.k@intel.com>
Signed-off-by: RajaniRanjan <rajani.ranjan@intel.com>