### PR TITLE
Changing Accelerometer default value.

### DIFF
--- a/sensors/2.0/iiohal_mediation_v2.0/Sensor.cpp
+++ b/sensors/2.0/iiohal_mediation_v2.0/Sensor.cpp
@@ -160,7 +160,12 @@ std::vector<Event> Sensor::readEvents() {
         event.u.vec3.y = iioc->devlist[mSensorInfo.sensorHandle].data[1];
         event.u.vec3.z = iioc->devlist[mSensorInfo.sensorHandle].data[2];
     } else {
-        event.u.vec3.x = event.u.vec3.y = event.u.vec3.z = 0;
+        if (event.sensorHandle == 1) {
+            event.u.vec3.x = event.u.vec3.y = 0;
+            event.u.vec3.z = -9.8;
+        }
+        else
+            event.u.vec3.x = event.u.vec3.y = event.u.vec3.z = 0;
     }
     event.u.vec3.status = SensorStatus::ACCURACY_HIGH;
     events.push_back(event);


### PR DESCRIPTION
Device orientation has a dependency on sensors value.
when sensors-mediation is present ,framework is setting
correct device orientation as it can read accelerometer
values from sensors. when sensors are not present,
orientation is set to 270.

So, setting Accelerometer default values according to
framework requirement.

Tracked-On: OAM-102984
Signed-off-by: RajaniRanjan <rajani.ranjan@intel.com>
Signed-off-by: vilasrk vilas.r.k@intel.com