### PR TITLE
[Bluetooth] Fix build issues and update dependency path

### DIFF
--- a/bluetooth/Android.bp
+++ b/bluetooth/Android.bp
@@ -18,8 +18,8 @@ cc_binary {
     proprietary: true,
     relative_install_path: "hw",
     include_dirs: [
-        "system/bt/device/include",
-        "system/bt/stack/include"
+        "packages/modules/Bluetooth/system/device/include",
+        "packages/modules/Bluetooth/system/stack/include"
     ],
     srcs: [
         "async_fd_watcher.cc",

--- a/bluetooth/h4_protocol.cc
+++ b/bluetooth/h4_protocol.cc
@@ -15,7 +15,6 @@
 //
 
 #include "h4_protocol.h"
-#include "hcidefs.h"
 
 #define LOG_TAG "android.hardware.bluetooth-hci-h4"
 
@@ -24,6 +23,15 @@
 #include <asm/byteorder.h>
 #include <linux/usb/ch9.h>
 #include <libusb/libusb.h>
+
+#define HCI_COMMAND_COMPLETE_EVT 0x0E
+#define HCI_COMMAND_STATUS_EVT 0x0F
+#define HCI_ESCO_CONNECTION_COMP_EVT 0x2C
+#define HCI_RESET_SUPPORTED(x) ((x)[5] & 0x80)
+#define HCI_GRP_INFORMATIONAL_PARAMS (0x04 << 10)    /* 0x1000 */
+#define HCI_READ_LOCAL_SUPPORTED_CMDS (0x0002 | HCI_GRP_INFORMATIONAL_PARAMS)
+#define HCI_GRP_HOST_CONT_BASEBAND_CMDS (0x03 << 10) /* 0x0C00 */
+#define HCI_RESET (0x0003 | HCI_GRP_HOST_CONT_BASEBAND_CMDS)
 
 #define INTEL_VID 0x8087
 #define INTEL_PID_8265 0x0a2b // Windstorm peak

--- a/bluetooth/vendor_interface.cc
+++ b/bluetooth/vendor_interface.cc
@@ -23,9 +23,6 @@
 #include <dlfcn.h>
 #include <fcntl.h>
 
-#include "esco_parameters.h"
-#include "hcidefs.h"
-
 #include "bluetooth_address.h"
 #include "h4_protocol.h"
 #include "mct_protocol.h"


### PR DESCRIPTION
Fix build issues and update dependency path for Android T Bluetooth

Add patches to vendor hardware interface to clean up BSP diff

Tracked-On: OAM-103630
Signed-off-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>