### PR TITLE
Battery percentage for Android in Virtual Machine

### DIFF
--- a/health/aidl/Android.bp
+++ b/health/aidl/Android.bp
@@ -1,0 +1,161 @@
+// Copyright (C) 2021 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package {
+    // See: http://go/android-license-faq
+    // A large-scale-change added 'default_applicable_licenses' to import
+    // all of the 'license_kinds' from "hardware_interfaces_license"
+    // to get the below license kinds:
+    //   SPDX-license-identifier-Apache-2.0
+    default_applicable_licenses: ["hardware_interfaces_license"],
+}
+
+cc_defaults {
+    name: "libhealth_aidl_common_defaults",
+    shared_libs: [
+        "libbase",
+        "libbinder_ndk",
+        "libcutils",
+        "liblog",
+        "libutils",
+        "android.hardware.health-V1-ndk",
+
+        // TODO(b/177269435): remove when BatteryMonitor works with AIDL HealthInfo.
+        "libhidlbase",
+    ],
+    static_libs: [
+        "libbatterymonitor",
+        "libhealthloop",
+
+        // TODO(b/177269435): remove when BatteryMonitor works with AIDL HealthInfo.
+        "android.hardware.health-translate-ndk",
+    ],
+}
+
+// Dependency to libhealthd_charger_ui. No UI in recovery.
+cc_defaults {
+    name: "libhealth_aidl_charger_defaults",
+    shared_libs: [
+        // common
+        "android.hardware.health-V1-ndk",
+        "libbase",
+        "libcutils",
+        "liblog",
+        "libutils",
+
+        // charger UI only
+        "libpng",
+    ],
+
+    static_libs: [
+        // common
+        "libbatterymonitor",
+        "libhealthloop",
+
+        // charger UI only
+        "libhealthd_draw",
+        "libhealthd_charger_ui",
+        "libminui",
+        "libsuspend",
+    ],
+
+    target: {
+        recovery: {
+            // No UI and libsuspend for recovery charger.
+            cflags: [
+                "-DCHARGER_FORCE_NO_UI=1",
+            ],
+            exclude_shared_libs: [
+                "libpng",
+            ],
+            exclude_static_libs: [
+                "libhealthd_draw",
+                "libhealthd_charger_ui",
+                "libminui",
+                "libsuspend",
+            ],
+        },
+    },
+}
+
+// AIDL version of libhealth2impl.
+// A helper library for health HAL implementation.
+// HAL implementations can link to this library and extend the Health class.
+cc_library_static {
+    name: "libhealth_aidl_impl",
+    defaults: [
+        "libhealth_aidl_common_defaults",
+        "libhealth_aidl_charger_defaults",
+    ],
+    vendor: true,
+    recovery_available: true,
+    export_include_dirs: ["include"],
+    export_static_lib_headers: [
+        "libbatterymonitor",
+    ],
+    srcs: [
+        "ChargerUtils.cpp",
+        "health-convert.cpp",
+        "HalHealthLoop.cpp",
+        "Health.cpp",
+        "LinkedCallback.cpp",
+    ],
+    target: {
+        recovery: {
+            exclude_srcs: [
+                "ChargerUtils.cpp",
+            ],
+        },
+    },
+}
+
+// Users of libhealth_aidl_impl should use this defaults.
+cc_defaults {
+    name: "libhealth_aidl_impl_user",
+    defaults: [
+        "libhealth_aidl_common_defaults",
+        "libhealth_aidl_charger_defaults",
+    ],
+}
+
+// AIDL version of android.hardware.health@2.1-service.
+// Default binder service of the health HAL.
+cc_defaults {
+    name: "android.hardware.health-service.example-defaults",
+    relative_install_path: "hw",
+    vintf_fragments: ["android.hardware.health-service.example.xml"],
+    defaults: [
+        "libhealth_aidl_impl_user",
+    ],
+    static_libs: [
+        "libhealth_aidl_impl",
+    ],
+    srcs: ["main.cpp"],
+}
+
+cc_binary {
+    name: "android.hardware.health-service.example",
+    vendor: true,
+    defaults: ["android.hardware.health-service.example-defaults"],
+    init_rc: ["android.hardware.health-service.example.rc"],
+    overrides: ["charger"],
+}
+
+cc_binary {
+    name: "android.hardware.health-service.example_recovery",
+    recovery: true,
+    defaults: ["android.hardware.health-service.example-defaults"],
+    init_rc: ["android.hardware.health-service.example_recovery.rc"],
+    overrides: ["charger.recovery"],
+}

--- a/health/aidl/Android.bp
+++ b/health/aidl/Android.bp
@@ -12,17 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package {
-    // See: http://go/android-license-faq
-    // A large-scale-change added 'default_applicable_licenses' to import
-    // all of the 'license_kinds' from "hardware_interfaces_license"
-    // to get the below license kinds:
-    //   SPDX-license-identifier-Apache-2.0
-    default_applicable_licenses: ["hardware_interfaces_license"],
-}
-
 cc_defaults {
-    name: "libhealth_aidl_common_defaults",
+    name: "libhealth_aidl_common_defaults.intel",
     shared_libs: [
         "libbase",
         "libbinder_ndk",
@@ -36,7 +27,7 @@ cc_defaults {
     ],
     static_libs: [
         "libbatterymonitor",
-        "libhealthloop",
+        "libhealthloop-aidl.intel",
 
         // TODO(b/177269435): remove when BatteryMonitor works with AIDL HealthInfo.
         "android.hardware.health-translate-ndk",
@@ -45,7 +36,7 @@ cc_defaults {
 
 // Dependency to libhealthd_charger_ui. No UI in recovery.
 cc_defaults {
-    name: "libhealth_aidl_charger_defaults",
+    name: "libhealth_aidl_charger_defaults.intel",
     shared_libs: [
         // common
         "android.hardware.health-V1-ndk",
@@ -53,7 +44,6 @@ cc_defaults {
         "libcutils",
         "liblog",
         "libutils",
-
         // charger UI only
         "libpng",
     ],
@@ -61,7 +51,7 @@ cc_defaults {
     static_libs: [
         // common
         "libbatterymonitor",
-        "libhealthloop",
+        "libhealthloop-aidl.intel",
 
         // charger UI only
         "libhealthd_draw",
@@ -93,10 +83,10 @@ cc_defaults {
 // A helper library for health HAL implementation.
 // HAL implementations can link to this library and extend the Health class.
 cc_library_static {
-    name: "libhealth_aidl_impl",
+    name: "libhealth_aidl_impl.intel",
     defaults: [
-        "libhealth_aidl_common_defaults",
-        "libhealth_aidl_charger_defaults",
+        "libhealth_aidl_common_defaults.intel",
+        "libhealth_aidl_charger_defaults.intel",
     ],
     vendor: true,
     recovery_available: true,
@@ -122,40 +112,34 @@ cc_library_static {
 
 // Users of libhealth_aidl_impl should use this defaults.
 cc_defaults {
-    name: "libhealth_aidl_impl_user",
+    name: "libhealth_aidl_impl_user.intel",
     defaults: [
-        "libhealth_aidl_common_defaults",
-        "libhealth_aidl_charger_defaults",
+        "libhealth_aidl_common_defaults.intel",
+        "libhealth_aidl_charger_defaults.intel",
     ],
 }
 
 // AIDL version of android.hardware.health@2.1-service.
 // Default binder service of the health HAL.
 cc_defaults {
-    name: "android.hardware.health-service.example-defaults",
+    name: "android.hardware.health-service.intel-defaults",
     relative_install_path: "hw",
-    vintf_fragments: ["android.hardware.health-service.example.xml"],
+    vintf_fragments: ["android.hardware.health-service.intel.xml"],
     defaults: [
-        "libhealth_aidl_impl_user",
+        "libhealth_aidl_impl_user.intel",
     ],
     static_libs: [
-        "libhealth_aidl_impl",
+        "libhealth_aidl_impl.intel",
+        "libhealthd-aidl.intel",
     ],
     srcs: ["main.cpp"],
 }
 
 cc_binary {
-    name: "android.hardware.health-service.example",
+    name: "android.hardware.health-service.intel",
     vendor: true,
-    defaults: ["android.hardware.health-service.example-defaults"],
-    init_rc: ["android.hardware.health-service.example.rc"],
+    defaults: ["android.hardware.health-service.intel-defaults"],
+    init_rc: ["android.hardware.health-service.intel.rc"],
     overrides: ["charger"],
 }
 
-cc_binary {
-    name: "android.hardware.health-service.example_recovery",
-    recovery: true,
-    defaults: ["android.hardware.health-service.example-defaults"],
-    init_rc: ["android.hardware.health-service.example_recovery.rc"],
-    overrides: ["charger.recovery"],
-}

--- a/health/aidl/ChargerUtils.cpp
+++ b/health/aidl/ChargerUtils.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <android-base/logging.h>
+#include <health-impl/ChargerUtils.h>
+
+namespace aidl::android::hardware::health::charger {
+
+std::optional<bool> ChargerCallback::ChargerShouldKeepScreenOn() {
+    return service_->ShouldKeepScreenOn();
+}
+
+bool ChargerCallback::ChargerIsOnline() {
+    auto hal_health_loop_sp = hal_health_loop_.lock();
+    if (hal_health_loop_sp == nullptr) {
+        // Assume no charger
+        return false;
+    }
+    return hal_health_loop_sp->charger_online();
+}
+
+void ChargerCallback::ChargerInitConfig(healthd_config* config) {
+    auto hal_health_loop_sp = hal_health_loop_.lock();
+    if (hal_health_loop_sp == nullptr) {
+        return;
+    }
+    return service_->OnInit(hal_health_loop_sp.get(), config);
+}
+
+int ChargerCallback::ChargerRegisterEvent(int fd, BoundFunction func, EventWakeup wakeup) {
+    auto hal_health_loop_sp = hal_health_loop_.lock();
+    if (hal_health_loop_sp == nullptr) {
+        return -1;
+    }
+    return hal_health_loop_sp->RegisterEvent(fd, func, wakeup);
+}
+
+void ChargerCallback::set_hal_health_loop(const std::weak_ptr<HalHealthLoop>& hal_health_loop) {
+    hal_health_loop_ = std::move(hal_health_loop);
+}
+
+// Implements HalHealthLoopCallback for AIDL charger
+// Adapter of (Charger, Health) ->  HalHealthLoopCallback
+class LoopCallback : public HalHealthLoopCallback {
+  public:
+    LoopCallback(const std::shared_ptr<Health>& service, ChargerCallback* charger_callback)
+        : service_(service), charger_(std::make_unique<::android::Charger>(charger_callback)) {}
+
+    void OnHeartbeat() override {
+        service_->OnHeartbeat();
+        charger_->OnHeartbeat();
+    }
+    // Return the minimum timeout. Negative values are treated as no values.
+    int OnPrepareToWait() override {
+        int timeout1 = service_->OnPrepareToWait();
+        int timeout2 = charger_->OnPrepareToWait();
+
+        if (timeout1 < 0) return timeout2;
+        if (timeout2 < 0) return timeout1;
+        return std::min(timeout1, timeout2);
+    }
+
+    void OnInit(HalHealthLoop*, struct healthd_config* config) override {
+        // Charger::OnInit calls ChargerInitConfig, which calls into the real Health::OnInit.
+        charger_->OnInit(config);
+    }
+
+    void OnHealthInfoChanged(const HealthInfo& health_info) override {
+        charger_->OnHealthInfoChanged(::android::ChargerHealthInfo{
+                .battery_level = health_info.batteryLevel,
+                .battery_status = health_info.batteryStatus,
+        });
+        service_->OnHealthInfoChanged(health_info);
+    }
+
+  private:
+    std::shared_ptr<Health> service_;
+    std::unique_ptr<::android::Charger> charger_;
+};
+
+int ChargerModeMain(const std::shared_ptr<Health>& binder,
+                    const std::shared_ptr<ChargerCallback>& charger_callback) {
+    LOG(INFO) << "Starting charger mode.";
+    //   parent stack ==========================================
+    //   current stack                                         ||
+    //    ||                                                   ||
+    //    V                                                    V
+    // hal_health_loop => loop_callback => charger --(raw)--> charger_callback
+    //    ^----------------(weak)---------------------------------'
+    auto loop_callback = std::make_shared<LoopCallback>(binder, charger_callback.get());
+    auto hal_health_loop = std::make_shared<HalHealthLoop>(binder, std::move(loop_callback));
+    charger_callback->set_hal_health_loop(hal_health_loop);
+    return hal_health_loop->StartLoop();
+}
+
+}  // namespace aidl::android::hardware::health::charger

--- a/health/aidl/HalHealthLoop.cpp
+++ b/health/aidl/HalHealthLoop.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <health-impl/HalHealthLoop.h>
+
+#include <android-base/logging.h>
+
+#include <health-impl/Health.h>
+#include "health-convert.h"
+
+namespace aidl::android::hardware::health {
+
+// Unlike the HIDL version android::hardware::health::V2_1::implementation::HalHealthLoop,
+// do not define HalHealthLoop::Init because we no longer have Health::getHealthConfig.
+// Let the Health class handle Init.
+void HalHealthLoop::Init(struct healthd_config* config) {
+    callback_->OnInit(this, config);
+}
+
+void HalHealthLoop::Heartbeat() {
+    callback_->OnHeartbeat();
+}
+
+void HalHealthLoop::ScheduleBatteryUpdate() {
+    // ignore errors. impl may not be able to handle any callbacks, so
+    // update() may return errors.
+    if (auto res = service_->update(); !res.isOk()) {
+        LOG(WARNING) << "update() on the health HAL implementation failed with "
+                     << res.getDescription();
+    }
+
+    HealthInfo health_info;
+    auto res = service_->getHealthInfo(&health_info);
+    CHECK(res.isOk()) << "getHealthInfo() on the health HAL implementation failed with "
+                      << res.getDescription();
+    OnHealthInfoChanged(health_info);
+}
+
+int HalHealthLoop::PrepareToWait() {
+    return callback_->OnPrepareToWait();
+}
+
+void HalHealthLoop::OnHealthInfoChanged(const HealthInfo& health_info) {
+    callback_->OnHealthInfoChanged(health_info);
+    set_charger_online(health_info);
+    AdjustWakealarmPeriods(charger_online());
+}
+
+void HalHealthLoop::set_charger_online(const HealthInfo& health_info) {
+    charger_online_ = health_info.chargerAcOnline || health_info.chargerUsbOnline ||
+                      health_info.chargerWirelessOnline || health_info.chargerDockOnline;
+}
+
+}  // namespace aidl::android::hardware::health

--- a/health/aidl/Health.cpp
+++ b/health/aidl/Health.cpp
@@ -1,0 +1,338 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "health-impl/Health.h"
+
+#include <android-base/file.h>
+#include <android-base/logging.h>
+#include <android/binder_manager.h>
+#include <android/binder_process.h>
+#include <android/hardware/health/translate-ndk.h>
+#include <health/utils.h>
+
+#include "LinkedCallback.h"
+#include "health-convert.h"
+
+using std::string_literals::operator""s;
+
+namespace aidl::android::hardware::health {
+
+namespace {
+// Wrap LinkedCallback::OnCallbackDied() into a void(void*).
+void OnCallbackDiedWrapped(void* cookie) {
+    LinkedCallback* linked = reinterpret_cast<LinkedCallback*>(cookie);
+    linked->OnCallbackDied();
+}
+}  // namespace
+
+/*
+// If you need to call healthd_board_init, construct the Health instance with
+// the healthd_config after calling healthd_board_init:
+class MyHealth : public Health {
+  protected:
+    MyHealth() : Health(CreateConfig()) {}
+  private:
+    static std::unique_ptr<healthd_config> CreateConfig() {
+      auto config = std::make_unique<healthd_config>();
+      ::android::hardware::health::InitHealthdConfig(config.get());
+      healthd_board_init(config.get());
+      return std::move(config);
+    }
+};
+*/
+Health::Health(std::string_view instance_name, std::unique_ptr<struct healthd_config>&& config)
+    : instance_name_(instance_name),
+      healthd_config_(std::move(config)),
+      death_recipient_(AIBinder_DeathRecipient_new(&OnCallbackDiedWrapped)) {
+    battery_monitor_.init(healthd_config_.get());
+}
+
+Health::~Health() {}
+
+//
+// Getters.
+//
+
+template <typename T>
+static ndk::ScopedAStatus GetProperty(::android::BatteryMonitor* monitor, int id, T defaultValue,
+                                      T* out) {
+    *out = defaultValue;
+    struct ::android::BatteryProperty prop;
+    ::android::status_t err = monitor->getProperty(static_cast<int>(id), &prop);
+    if (err == ::android::OK) {
+        *out = static_cast<T>(prop.valueInt64);
+    } else {
+        LOG(DEBUG) << "getProperty(" << id << ")"
+                   << " fails: (" << err << ") " << ::android::statusToString(err);
+    }
+
+    switch (err) {
+        case ::android::OK:
+            return ndk::ScopedAStatus::ok();
+        case ::android::NAME_NOT_FOUND:
+            return ndk::ScopedAStatus::fromExceptionCode(EX_UNSUPPORTED_OPERATION);
+        default:
+            return ndk::ScopedAStatus::fromServiceSpecificErrorWithMessage(
+                    IHealth::STATUS_UNKNOWN, ::android::statusToString(err).c_str());
+    }
+}
+
+ndk::ScopedAStatus Health::getChargeCounterUah(int32_t* out) {
+    return GetProperty<int32_t>(&battery_monitor_, ::android::BATTERY_PROP_CHARGE_COUNTER, 0, out);
+}
+
+ndk::ScopedAStatus Health::getCurrentNowMicroamps(int32_t* out) {
+    return GetProperty<int32_t>(&battery_monitor_, ::android::BATTERY_PROP_CURRENT_NOW, 0, out);
+}
+
+ndk::ScopedAStatus Health::getCurrentAverageMicroamps(int32_t* out) {
+    return GetProperty<int32_t>(&battery_monitor_, ::android::BATTERY_PROP_CURRENT_AVG, 0, out);
+}
+
+ndk::ScopedAStatus Health::getCapacity(int32_t* out) {
+    return GetProperty<int32_t>(&battery_monitor_, ::android::BATTERY_PROP_CAPACITY, 0, out);
+}
+
+ndk::ScopedAStatus Health::getEnergyCounterNwh(int64_t* out) {
+    return GetProperty<int64_t>(&battery_monitor_, ::android::BATTERY_PROP_ENERGY_COUNTER, 0, out);
+}
+
+ndk::ScopedAStatus Health::getChargeStatus(BatteryStatus* out) {
+    return GetProperty(&battery_monitor_, ::android::BATTERY_PROP_BATTERY_STATUS,
+                       BatteryStatus::UNKNOWN, out);
+}
+
+ndk::ScopedAStatus Health::getDiskStats(std::vector<DiskStats>*) {
+    // This implementation does not support DiskStats. An implementation may extend this
+    // class and override this function to support disk stats.
+    return ndk::ScopedAStatus::fromExceptionCode(EX_UNSUPPORTED_OPERATION);
+}
+
+ndk::ScopedAStatus Health::getStorageInfo(std::vector<StorageInfo>*) {
+    // This implementation does not support StorageInfo. An implementation may extend this
+    // class and override this function to support storage info.
+    return ndk::ScopedAStatus::fromExceptionCode(EX_UNSUPPORTED_OPERATION);
+}
+
+ndk::ScopedAStatus Health::getHealthInfo(HealthInfo* out) {
+    battery_monitor_.updateValues();
+
+    *out = battery_monitor_.getHealthInfo();
+
+    // Fill in storage infos; these aren't retrieved by BatteryMonitor.
+    if (auto res = getStorageInfo(&out->storageInfos); !res.isOk()) {
+        if (res.getServiceSpecificError() == 0 &&
+            res.getExceptionCode() != EX_UNSUPPORTED_OPERATION) {
+            return ndk::ScopedAStatus::fromServiceSpecificErrorWithMessage(
+                    IHealth::STATUS_UNKNOWN,
+                    ("getStorageInfo fails: " + res.getDescription()).c_str());
+        }
+        LOG(DEBUG) << "getHealthInfo: getStorageInfo fails with service-specific error, clearing: "
+                   << res.getDescription();
+        out->storageInfos = {};
+    }
+    if (auto res = getDiskStats(&out->diskStats); !res.isOk()) {
+        if (res.getServiceSpecificError() == 0 &&
+            res.getExceptionCode() != EX_UNSUPPORTED_OPERATION) {
+            return ndk::ScopedAStatus::fromServiceSpecificErrorWithMessage(
+                    IHealth::STATUS_UNKNOWN,
+                    ("getDiskStats fails: " + res.getDescription()).c_str());
+        }
+        LOG(DEBUG) << "getHealthInfo: getDiskStats fails with service-specific error, clearing: "
+                   << res.getDescription();
+        out->diskStats = {};
+    }
+
+    // A subclass may want to update health info struct before returning it.
+    UpdateHealthInfo(out);
+
+    return ndk::ScopedAStatus::ok();
+}
+
+binder_status_t Health::dump(int fd, const char**, uint32_t) {
+    battery_monitor_.dumpState(fd);
+
+    ::android::base::WriteStringToFd("\ngetHealthInfo -> ", fd);
+    HealthInfo health_info;
+    auto res = getHealthInfo(&health_info);
+    if (res.isOk()) {
+        ::android::base::WriteStringToFd(health_info.toString(), fd);
+    } else {
+        ::android::base::WriteStringToFd(res.getDescription(), fd);
+    }
+
+    fsync(fd);
+    return STATUS_OK;
+}
+
+std::optional<bool> Health::ShouldKeepScreenOn() {
+    if (!healthd_config_->screen_on) {
+        return std::nullopt;
+    }
+
+    HealthInfo health_info;
+    auto res = getHealthInfo(&health_info);
+    if (!res.isOk()) {
+        return std::nullopt;
+    }
+
+    ::android::BatteryProperties props = {};
+    convert(health_info, &props);
+    return healthd_config_->screen_on(&props);
+}
+
+namespace {
+bool IsDeadObjectLogged(const ndk::ScopedAStatus& ret) {
+    if (ret.isOk()) return false;
+    if (ret.getStatus() == ::STATUS_DEAD_OBJECT) return true;
+    LOG(ERROR) << "Cannot call healthInfoChanged on callback: " << ret.getDescription();
+    return false;
+}
+}  // namespace
+
+//
+// Subclass helpers / overrides
+//
+
+void Health::UpdateHealthInfo(HealthInfo* /* health_info */) {
+    /*
+        // Sample code for a subclass to implement this:
+        // If you need to modify values (e.g. batteryChargeTimeToFullNowSeconds), do it here.
+        health_info->batteryChargeTimeToFullNowSeconds = calculate_charge_time_seconds();
+
+        // If you need to call healthd_board_battery_update, modify its signature
+        // and implementation to operate on HealthInfo directly, then call:
+        healthd_board_battery_update(health_info);
+    */
+}
+
+//
+// Methods that handle callbacks.
+//
+
+ndk::ScopedAStatus Health::registerCallback(const std::shared_ptr<IHealthInfoCallback>& callback) {
+    if (callback == nullptr) {
+        // For now, this shouldn't happen because argument is not nullable.
+        return ndk::ScopedAStatus::fromExceptionCode(EX_NULL_POINTER);
+    }
+
+    {
+        std::lock_guard<decltype(callbacks_lock_)> lock(callbacks_lock_);
+        callbacks_.emplace_back(LinkedCallback::Make(ref<Health>(), callback));
+        // unlock
+    }
+
+    HealthInfo health_info;
+    if (auto res = getHealthInfo(&health_info); !res.isOk()) {
+        LOG(WARNING) << "Cannot call getHealthInfo: " << res.getDescription();
+        // No health info to send, so return early.
+        return ndk::ScopedAStatus::ok();
+    }
+
+    if (auto res = callback->healthInfoChanged(health_info); IsDeadObjectLogged(res)) {
+        (void)unregisterCallback(callback);
+    }
+    return ndk::ScopedAStatus::ok();
+}
+
+ndk::ScopedAStatus Health::unregisterCallback(
+        const std::shared_ptr<IHealthInfoCallback>& callback) {
+    if (callback == nullptr) {
+        // For now, this shouldn't happen because argument is not nullable.
+        return ndk::ScopedAStatus::fromExceptionCode(EX_NULL_POINTER);
+    }
+
+    std::lock_guard<decltype(callbacks_lock_)> lock(callbacks_lock_);
+
+    auto matches = [callback](const auto& linked) {
+        return linked->callback()->asBinder() == callback->asBinder();  // compares binder object
+    };
+    auto it = std::remove_if(callbacks_.begin(), callbacks_.end(), matches);
+    bool removed = (it != callbacks_.end());
+    callbacks_.erase(it, callbacks_.end());  // calls unlinkToDeath on deleted callbacks.
+    return removed ? ndk::ScopedAStatus::ok()
+                   : ndk::ScopedAStatus::fromExceptionCode(EX_ILLEGAL_ARGUMENT);
+}
+
+// A combination of the HIDL version
+//   android::hardware::health::V2_1::implementation::Health::update() and
+//   android::hardware::health::V2_1::implementation::BinderHealth::update()
+ndk::ScopedAStatus Health::update() {
+    HealthInfo health_info;
+    if (auto res = getHealthInfo(&health_info); !res.isOk()) {
+        LOG(DEBUG) << "Cannot call getHealthInfo for update(): " << res.getDescription();
+        // Propagate service specific errors. If there's none, report unknown error.
+        if (res.getServiceSpecificError() != 0 ||
+            res.getExceptionCode() == EX_UNSUPPORTED_OPERATION) {
+            return res;
+        }
+        return ndk::ScopedAStatus::fromServiceSpecificErrorWithMessage(
+                IHealth::STATUS_UNKNOWN, res.getDescription().c_str());
+    }
+    battery_monitor_.logValues();
+    OnHealthInfoChanged(health_info);
+    return ndk::ScopedAStatus::ok();
+}
+
+void Health::OnHealthInfoChanged(const HealthInfo& health_info) {
+    // Notify all callbacks
+    std::unique_lock<decltype(callbacks_lock_)> lock(callbacks_lock_);
+    // is_dead notifies a callback and return true if it is dead.
+    auto is_dead = [&](const auto& linked) {
+        auto res = linked->callback()->healthInfoChanged(health_info);
+        return IsDeadObjectLogged(res);
+    };
+    auto it = std::remove_if(callbacks_.begin(), callbacks_.end(), is_dead);
+    callbacks_.erase(it, callbacks_.end());  // calls unlinkToDeath on deleted callbacks.
+    lock.unlock();
+
+    // Let HalHealthLoop::OnHealthInfoChanged() adjusts uevent / wakealarm periods
+}
+
+void Health::BinderEvent(uint32_t /*epevents*/) {
+    if (binder_fd_ >= 0) {
+        ABinderProcess_handlePolledCommands();
+    }
+}
+
+void Health::OnInit(HalHealthLoop* hal_health_loop, struct healthd_config* config) {
+    LOG(INFO) << instance_name_ << " instance initializing with healthd_config...";
+
+    // Similar to HIDL's android::hardware::health::V2_1::implementation::HalHealthLoop::Init,
+    // copy configuration parameters to |config| for HealthLoop (e.g. uevent / wake alarm periods)
+    *config = *healthd_config_.get();
+
+    binder_status_t status = ABinderProcess_setupPolling(&binder_fd_);
+
+    if (status == ::STATUS_OK && binder_fd_ >= 0) {
+        std::shared_ptr<Health> thiz = ref<Health>();
+        auto binder_event = [thiz](auto*, uint32_t epevents) { thiz->BinderEvent(epevents); };
+        if (hal_health_loop->RegisterEvent(binder_fd_, binder_event, EVENT_NO_WAKEUP_FD) != 0) {
+            PLOG(ERROR) << instance_name_ << " instance: Register for binder events failed";
+        }
+    }
+
+    std::string health_name = IHealth::descriptor + "/"s + instance_name_;
+    CHECK_EQ(STATUS_OK, AServiceManager_addService(this->asBinder().get(), health_name.c_str()))
+            << instance_name_ << ": Failed to register HAL";
+
+    LOG(INFO) << instance_name_ << ": Hal init done";
+}
+
+// Unlike hwbinder, for binder, there's no need to explicitly call flushCommands()
+// in PrepareToWait(). See b/139697085.
+
+}  // namespace aidl::android::hardware::health

--- a/health/aidl/LinkedCallback.cpp
+++ b/health/aidl/LinkedCallback.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <android-base/logging.h>
+#include <android/binder_ibinder.h>
+
+#include <health-impl/Health.h>
+#include <utils/Errors.h>
+
+#include "LinkedCallback.h"
+
+namespace aidl::android::hardware::health {
+
+std::unique_ptr<LinkedCallback> LinkedCallback::Make(
+        std::shared_ptr<Health> service, std::shared_ptr<IHealthInfoCallback> callback) {
+    std::unique_ptr<LinkedCallback> ret(new LinkedCallback());
+    binder_status_t linkRet =
+            AIBinder_linkToDeath(callback->asBinder().get(), service->death_recipient_.get(),
+                                 reinterpret_cast<void*>(ret.get()));
+    if (linkRet != ::STATUS_OK) {
+        LOG(WARNING) << __func__ << "Cannot link to death: " << linkRet;
+        return nullptr;
+    }
+    ret->service_ = service;
+    ret->callback_ = std::move(callback);
+    return ret;
+}
+
+LinkedCallback::LinkedCallback() = default;
+
+LinkedCallback::~LinkedCallback() {
+    if (callback_ == nullptr) {
+        return;
+    }
+    auto status =
+            AIBinder_unlinkToDeath(callback_->asBinder().get(), service()->death_recipient_.get(),
+                                   reinterpret_cast<void*>(this));
+    if (status != STATUS_OK && status != STATUS_DEAD_OBJECT) {
+        LOG(WARNING) << __func__ << "Cannot unlink to death: " << ::android::statusToString(status);
+    }
+}
+
+std::shared_ptr<Health> LinkedCallback::service() {
+    auto service_sp = service_.lock();
+    CHECK_NE(nullptr, service_sp);
+    return service_sp;
+}
+
+void LinkedCallback::OnCallbackDied() {
+    service()->unregisterCallback(callback_);
+}
+
+}  // namespace aidl::android::hardware::health

--- a/health/aidl/LinkedCallback.h
+++ b/health/aidl/LinkedCallback.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include <aidl/android/hardware/health/IHealthInfoCallback.h>
+#include <android-base/macros.h>
+#include <android/binder_auto_utils.h>
+
+#include <health-impl/Health.h>
+
+namespace aidl::android::hardware::health {
+
+// Type of the cookie pointer in linkToDeath.
+// A (Health, IHealthInfoCallback) tuple.
+class LinkedCallback {
+  public:
+    // Automatically linkToDeath upon construction with the returned object as the cookie.
+    // service->death_reciepient() should be from CreateDeathRecipient().
+    // Not using a strong reference to |service| to avoid circular reference. The lifetime
+    // of |service| must be longer than this LinkedCallback object.
+    static std::unique_ptr<LinkedCallback> Make(std::shared_ptr<Health> service,
+                                                std::shared_ptr<IHealthInfoCallback> callback);
+
+    // Automatically unlinkToDeath upon destruction. So, it is always safe to reinterpret_cast
+    // the cookie back to the LinkedCallback object.
+    ~LinkedCallback();
+
+    // The wrapped IHealthInfoCallback object.
+    const std::shared_ptr<IHealthInfoCallback>& callback() const { return callback_; }
+
+    // On callback died, unreigster it from the service.
+    void OnCallbackDied();
+
+  private:
+    LinkedCallback();
+    DISALLOW_COPY_AND_ASSIGN(LinkedCallback);
+
+    std::shared_ptr<Health> service();
+
+    std::weak_ptr<Health> service_;
+    std::shared_ptr<IHealthInfoCallback> callback_;
+};
+
+}  // namespace aidl::android::hardware::health

--- a/health/aidl/android.hardware.health-service.example.rc
+++ b/health/aidl/android.hardware.health-service.example.rc
@@ -1,0 +1,17 @@
+service vendor.health-default /vendor/bin/hw/android.hardware.health-service.example
+    class hal
+    user system
+    group system
+    capabilities WAKE_ALARM BLOCK_SUSPEND
+    file /dev/kmsg w
+
+service vendor.charger /vendor/bin/hw/android.hardware.health-service.example --charger
+    class charger
+    seclabel u:r:charger_vendor:s0
+    user system
+    group system wakelock input
+    capabilities SYS_BOOT
+    file /dev/kmsg w
+    file /sys/fs/pstore/console-ramoops-0 r
+    file /sys/fs/pstore/console-ramoops r
+    file /proc/last_kmsg r

--- a/health/aidl/android.hardware.health-service.example.xml
+++ b/health/aidl/android.hardware.health-service.example.xml
@@ -1,0 +1,7 @@
+<manifest version="1.0" type="device">
+    <hal format="aidl">
+        <name>android.hardware.health</name>
+        <version>1</version>
+        <fqname>IHealth/default</fqname>
+    </hal>
+</manifest>

--- a/health/aidl/android.hardware.health-service.example_recovery.rc
+++ b/health/aidl/android.hardware.health-service.example_recovery.rc
@@ -1,0 +1,7 @@
+service vendor.health-default /system/bin/hw/android.hardware.health-service.example_recovery
+    class hal
+    seclabel u:r:hal_health_default:s0
+    user system
+    group system
+    capabilities WAKE_ALARM BLOCK_SUSPEND
+    file /dev/kmsg w

--- a/health/aidl/android.hardware.health-service.intel.rc
+++ b/health/aidl/android.hardware.health-service.intel.rc
@@ -1,0 +1,18 @@
+service vendor.health-default /vendor/bin/hw/android.hardware.health-service.intel
+    interface aidl android.hardware.health.IHealth/default
+    class hal
+    user system
+    group system
+    capabilities WAKE_ALARM BLOCK_SUSPEND
+    file /dev/kmsg w
+
+service vendor.charger /vendor/bin/hw/android.hardware.health-service.intel --charger
+    class charger
+    seclabel u:r:charger_vendor:s0
+    user system
+    group system wakelock input
+    capabilities SYS_BOOT
+    file /dev/kmsg w
+    file /sys/fs/pstore/console-ramoops-0 r
+    file /sys/fs/pstore/console-ramoops r
+    file /proc/last_kmsg r

--- a/health/aidl/android.hardware.health-service.intel.xml
+++ b/health/aidl/android.hardware.health-service.intel.xml
@@ -1,0 +1,7 @@
+<manifest version="1.0" type="device">
+    <hal format="aidl">
+        <name>android.hardware.health</name>
+        <version>1</version>
+        <fqname>IHealth/default</fqname>
+    </hal>
+</manifest>

--- a/health/aidl/health-convert.cpp
+++ b/health/aidl/health-convert.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "health-convert.h"
+
+namespace aidl::android::hardware::health {
+
+void convert(const HealthInfo& info, struct ::android::BatteryProperties* p) {
+    p->chargerAcOnline = info.chargerAcOnline;
+    p->chargerUsbOnline = info.chargerUsbOnline;
+    p->chargerWirelessOnline = info.chargerWirelessOnline;
+    p->chargerDockOnline = info.chargerDockOnline;
+    p->maxChargingCurrent = info.maxChargingCurrentMicroamps;
+    p->maxChargingVoltage = info.maxChargingVoltageMicrovolts;
+    p->batteryStatus = static_cast<int>(info.batteryStatus);
+    p->batteryHealth = static_cast<int>(info.batteryHealth);
+    p->batteryPresent = info.batteryPresent;
+    p->batteryLevel = info.batteryLevel;
+    p->batteryVoltage = info.batteryVoltageMillivolts;
+    p->batteryTemperature = info.batteryTemperatureTenthsCelsius;
+    p->batteryCurrent = info.batteryCurrentMicroamps;
+    p->batteryCycleCount = info.batteryCycleCount;
+    p->batteryFullCharge = info.batteryFullChargeUah;
+    p->batteryChargeCounter = info.batteryChargeCounterUah;
+    p->batteryTechnology = ::android::String8(info.batteryTechnology.c_str());
+}
+
+}  // namespace aidl::android::hardware::health

--- a/health/aidl/health-convert.cpp
+++ b/health/aidl/health-convert.cpp
@@ -18,7 +18,7 @@
 
 namespace aidl::android::hardware::health {
 
-void convert(const HealthInfo& info, struct ::android::BatteryProperties* p) {
+void convertHealthinfoToBattery(const HealthInfo& info, struct ::android::BatteryProperties* p) {
     p->chargerAcOnline = info.chargerAcOnline;
     p->chargerUsbOnline = info.chargerUsbOnline;
     p->chargerWirelessOnline = info.chargerWirelessOnline;
@@ -37,5 +37,23 @@ void convert(const HealthInfo& info, struct ::android::BatteryProperties* p) {
     p->batteryChargeCounter = info.batteryChargeCounterUah;
     p->batteryTechnology = ::android::String8(info.batteryTechnology.c_str());
 }
-
+void convertHealthinfoFromoBattery(const struct ::android::BatteryProperties* p, HealthInfo& info) {
+    info.chargerAcOnline = p->chargerAcOnline;
+    info.chargerUsbOnline = p->chargerUsbOnline;
+    info.chargerWirelessOnline = p->chargerWirelessOnline;
+    info.chargerDockOnline = p->chargerDockOnline;
+    info.maxChargingCurrentMicroamps = p->maxChargingCurrent;
+    info.maxChargingVoltageMicrovolts = p->maxChargingVoltage;
+    info.batteryStatus = static_cast<BatteryStatus>(p->batteryStatus);
+    info.batteryHealth = static_cast<BatteryHealth>(p->batteryHealth);
+    info.batteryPresent = p->batteryPresent;
+    info.batteryLevel = p->batteryLevel;
+    info.batteryVoltageMillivolts = p->batteryVoltage;
+    info.batteryTemperatureTenthsCelsius = p->batteryTemperature;
+    info.batteryCurrentMicroamps = p->batteryCurrent;
+    info.batteryCycleCount = p->batteryCycleCount;
+    info.batteryFullChargeUah = p->batteryFullCharge;
+    info.batteryChargeCounterUah = p->batteryChargeCounter;
+    info.batteryTechnology = p->batteryTechnology;
+}
 }  // namespace aidl::android::hardware::health

--- a/health/aidl/health-convert.h
+++ b/health/aidl/health-convert.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <aidl/android/hardware/health/HealthInfo.h>
+#include <batteryservice/BatteryService.h>
+#include <healthd/healthd.h>
+
+// Conversion between healthd types and AIDL health HAL types. Note that most
+// of the conversion loses information, because these types have a different
+// set of information.
+
+namespace aidl::android::hardware::health {
+
+void convert(const HealthInfo& info, struct ::android::BatteryProperties* out);
+
+}  // namespace aidl::android::hardware::health

--- a/health/aidl/health-convert.h
+++ b/health/aidl/health-convert.h
@@ -26,6 +26,7 @@
 
 namespace aidl::android::hardware::health {
 
-void convert(const HealthInfo& info, struct ::android::BatteryProperties* out);
+void convertHealthinfoToBattery(const HealthInfo& info, struct ::android::BatteryProperties* out);
+void convertHealthinfoFromoBattery(const struct ::android::BatteryProperties* out, HealthInfo& info);
 
 }  // namespace aidl::android::hardware::health

--- a/health/aidl/include/health-impl/ChargerUtils.h
+++ b/health/aidl/include/health-impl/ChargerUtils.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <optional>
+#include <type_traits>
+
+#include <android/binder_auto_utils.h>
+#include <charger/healthd_mode_charger.h>
+#include <health-impl/Health.h>
+
+#pragma once
+
+namespace aidl::android::hardware::health::charger {
+
+// Implements ChargerHalHealthLoopInterface for AIDL charger
+// Adapter of (Health, HalHealthLoop) -> ChargerHalHealthLoopInterface
+class ChargerCallback : public ::android::ChargerConfigurationInterface {
+  public:
+    ChargerCallback(const std::shared_ptr<Health>& service) : service_(service) {}
+    std::optional<bool> ChargerShouldKeepScreenOn() override;
+    bool ChargerIsOnline() override;
+    void ChargerInitConfig(healthd_config* config) override;
+    int ChargerRegisterEvent(int fd, BoundFunction func, EventWakeup wakeup) override;
+
+    // Override to return true to replace `ro.charger.enable_suspend=true`
+    bool ChargerEnableSuspend() override { return false; }
+
+    void set_hal_health_loop(const std::weak_ptr<HalHealthLoop>& hal_health_loop);
+
+  private:
+    std::shared_ptr<Health> service_;
+    std::weak_ptr<HalHealthLoop> hal_health_loop_;
+};
+
+int ChargerModeMain(const std::shared_ptr<Health>& binder,
+                    const std::shared_ptr<ChargerCallback>& charger_callback);
+
+}  // namespace aidl::android::hardware::health::charger

--- a/health/aidl/include/health-impl/HalHealthLoop.h
+++ b/health/aidl/include/health-impl/HalHealthLoop.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <optional>
+
+#include <aidl/android/hardware/health/IHealth.h>
+#include <health/HealthLoop.h>
+
+namespace aidl::android::hardware::health {
+
+class HalHealthLoop;
+
+class HalHealthLoopCallback {
+  public:
+    virtual ~HalHealthLoopCallback() = default;
+
+    // Called by HalHealthLoop::Init
+    virtual void OnInit(HalHealthLoop* hal_health_loop, struct healthd_config* config) = 0;
+    // Called by HalHealthLoop::Heartbeat
+    virtual void OnHeartbeat(){};
+    // Called by HalHealthLoop::PrepareToWait
+    virtual int OnPrepareToWait() { return -1; }
+    // Called by HalHealthLoop::ScheduleBatteryUpdate
+    virtual void OnHealthInfoChanged(const HealthInfo&) {}
+};
+
+// AIDL version of android::hardware::health::V2_1::implementation::HalHealthLoop.
+// An implementation of HealthLoop for using a given health HAL.
+class HalHealthLoop final : public ::android::hardware::health::HealthLoop {
+  public:
+    // Caller must ensure that the lifetime of service_ is not shorter than this object.
+    HalHealthLoop(std::shared_ptr<IHealth> service, std::shared_ptr<HalHealthLoopCallback> callback)
+        : service_(std::move(service)), callback_(std::move(callback)) {}
+
+    using HealthLoop::RegisterEvent;
+
+    bool charger_online() const { return charger_online_; }
+
+  protected:
+    virtual void Init(struct healthd_config* config) override;
+    virtual void Heartbeat() override;
+    virtual int PrepareToWait() override;
+    virtual void ScheduleBatteryUpdate() override;
+
+  private:
+    std::shared_ptr<IHealth> service_;
+    std::shared_ptr<HalHealthLoopCallback> callback_;
+    bool charger_online_ = false;
+
+    // Helpers of OnHealthInfoChanged.
+    void set_charger_online(const HealthInfo& health_info);
+
+    // HealthLoop periodically calls ScheduleBatteryUpdate, which calls
+    // OnHealthInfoChanged callback. A subclass of the callback can override
+    // HalHealthLoopCallback::OnHealthInfoChanged to
+    // broadcast the health_info to interested listeners.
+    // This adjust uevents / wakealarm periods.
+    void OnHealthInfoChanged(const HealthInfo& health_info);
+};
+
+}  // namespace aidl::android::hardware::health

--- a/health/aidl/include/health-impl/Health.h
+++ b/health/aidl/include/health-impl/Health.h
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <optional>
+
+#include <aidl/android/hardware/health/BnHealth.h>
+#include <aidl/android/hardware/health/IHealthInfoCallback.h>
+#include <android/binder_auto_utils.h>
+#include <health-impl/HalHealthLoop.h>
+#include <healthd/BatteryMonitor.h>
+#include <healthd/healthd.h>
+
+namespace aidl::android::hardware::health {
+
+class LinkedCallback;
+
+// AIDL version of android::hardware::health::V2_1::implementation::Health and BinderHealth.
+// There's no need to separate the two in AIDL because AIDL does not support passthrough transport.
+//
+// Instead of inheriting from HalHealthLoop directly, implements the callback interface to
+// HalHealthLoop instead.
+//
+// Sample implementation of health HAL.
+class Health : public BnHealth, public HalHealthLoopCallback {
+  public:
+    // Initialize with |config|.
+    // A subclass may modify |config| before passing it to the parent constructor.
+    // See implementation of Health for code samples.
+    Health(std::string_view instance_name, std::unique_ptr<struct healthd_config>&& config);
+    virtual ~Health();
+
+    ndk::ScopedAStatus registerCallback(
+            const std::shared_ptr<IHealthInfoCallback>& callback) override;
+    ndk::ScopedAStatus unregisterCallback(
+            const std::shared_ptr<IHealthInfoCallback>& callback) override;
+    ndk::ScopedAStatus update() override;
+
+    // A subclass should not override this. Override UpdateHealthInfo instead.
+    ndk::ScopedAStatus getHealthInfo(HealthInfo* out) override final;
+
+    // A subclass is recommended to override the path in healthd_config in the constructor.
+    // Only override these if there are no suitable kernel interfaces to read these values.
+    ndk::ScopedAStatus getChargeCounterUah(int32_t* out) override;
+    ndk::ScopedAStatus getCurrentNowMicroamps(int32_t* out) override;
+    ndk::ScopedAStatus getCurrentAverageMicroamps(int32_t* out) override;
+    ndk::ScopedAStatus getCapacity(int32_t* out) override;
+    ndk::ScopedAStatus getChargeStatus(BatteryStatus* out) override;
+
+    // A subclass may either override these or provide function pointers in
+    // in healthd_config in the constructor.
+    // Prefer overriding these for efficiency.
+    ndk::ScopedAStatus getEnergyCounterNwh(int64_t* out) override;
+
+    // A subclass may override these for a specific device.
+    // The default implementations return nothing in |out|.
+    ndk::ScopedAStatus getDiskStats(std::vector<DiskStats>* out) override;
+    ndk::ScopedAStatus getStorageInfo(std::vector<StorageInfo>* out) override;
+
+    // A subclass may override these to provide a different implementation.
+    binder_status_t dump(int fd, const char** args, uint32_t num_args) override;
+
+    // HalHealthLoopCallback implementation.
+    void OnInit(HalHealthLoop* hal_health_loop, struct healthd_config* config) override;
+    void OnHealthInfoChanged(const HealthInfo& health_info) override;
+
+    // A subclass may override this if it wants to handle binder events differently.
+    virtual void BinderEvent(uint32_t epevents);
+
+    // A subclass may override this to determine whether screen should be kept on in charger mode.
+    // Default is to invoke healthd_config->screen_on() on the BatteryProperties converted
+    // from getHealthInfo.
+    // Prefer overriding these to providing screen_on in healthd_config in the constructor
+    // for efficiency.
+    virtual std::optional<bool> ShouldKeepScreenOn();
+
+  protected:
+    // A subclass can override this to modify any health info object before
+    // returning to clients. This is similar to healthd_board_battery_update().
+    // By default, it does nothing.
+    // See implementation of Health for code samples.
+    virtual void UpdateHealthInfo(HealthInfo* health_info);
+
+  private:
+    friend LinkedCallback;  // for exposing death_recipient_
+
+    bool unregisterCallbackInternal(std::shared_ptr<IHealthInfoCallback> callback);
+
+    std::string instance_name_;
+    ::android::BatteryMonitor battery_monitor_;
+    std::unique_ptr<struct healthd_config> healthd_config_;
+
+    ndk::ScopedAIBinder_DeathRecipient death_recipient_;
+    int binder_fd_ = -1;
+    std::mutex callbacks_lock_;
+    std::vector<std::unique_ptr<LinkedCallback>> callbacks_;
+};
+
+}  // namespace aidl::android::hardware::health

--- a/health/aidl/libhealthd/Android.bp
+++ b/health/aidl/libhealthd/Android.bp
@@ -1,0 +1,14 @@
+// Copyright 2016 The Android Open Source Project
+
+cc_library_static {
+    srcs: ["healthd_board_default.cpp"],
+    name: "libhealthd-aidl.intel",
+    vendor_available: true,
+    recovery_available: true,
+    cflags: ["-Werror"],
+    include_dirs: ["system/libbase/include"],
+    header_libs: ["libhealthd_headers"],
+    shared_libs: [
+        "libcutils",
+    ],
+}

--- a/health/aidl/libhealthd/battery_notifypkt.h
+++ b/health/aidl/libhealthd/battery_notifypkt.h
@@ -1,0 +1,58 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <healthd/BatteryMonitor.h>
+
+#define BASE_PATH "/sys/class/power_supply/test_battery/"
+#define INTELIPCID "INTELIPC"
+
+using namespace android;
+bool get_battery_mediation_present(void);
+bool get_battery_properties(android::BatteryProperties *props);
+
+struct header {
+    uint8_t intelipc[9];
+    uint16_t notify_id;
+    uint16_t length;
+};
+
+struct initial_pkt {
+    uint8_t model_name[28];
+    uint8_t serial_number[52];
+    uint8_t manufacturer[24];
+    uint8_t technology[8];
+    uint8_t type[8];
+    uint8_t present[4];
+};
+
+struct monitor_pkt {
+    uint32_t capacity;
+    uint32_t charge_full_design;
+    uint32_t temp;
+    uint32_t charge_now;
+    uint32_t time_to_empty_avg;
+    uint32_t charge_full;
+    uint32_t time_to_full_now;
+    uint32_t voltage_now;
+    uint8_t charge_type[12];
+    uint8_t capacity_level[12];
+    uint8_t status[12];
+    uint8_t health[24];
+};
+
+/* TODO Below structure is not getting used in this version of code.
+ * Next version will be using this.
+ *
+ * Size of the variable is same as passed on the network buffer.
+ * So any change in handling the below structure will not break
+ * the client code.
+ */
+struct battery_sysfs {
+    uint8_t intelipc[8];
+    uint8_t noftify_id[2];
+    uint8_t length[2];
+    
+    union   {
+        struct initial_pkt initpkt;
+        struct monitor_pkt monitorpkt;
+    };
+};

--- a/health/aidl/libhealthd/healthd_board_default.cpp
+++ b/health/aidl/libhealthd/healthd_board_default.cpp
@@ -1,0 +1,203 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <healthd/healthd.h>
+#include <thread>
+#include <sys/socket.h>
+#include <linux/vm_sockets.h>
+#include "battery_notifypkt.h"
+#include <cutils/klog.h>
+#include <unistd.h>
+#include <string.h>
+#define HLOG_TAG "android.hardware.health@aidl.intel"
+#define KLOG_LEVEL 6
+#define HEALTH_PORT 14196
+
+static std::thread vsock_thread;
+static struct android::BatteryProperties s_props;
+static bool is_vsock_present = false;
+int healthd_board_battery_update(struct android::BatteryProperties *props);
+
+static void parse_battery_status(uint8_t *status)
+{
+    if(!strncmp((char *)status, "Unknown", 7))
+        s_props.batteryStatus = android::BATTERY_STATUS_UNKNOWN;
+    else if(!strncmp((char *)status, "Charging", 8))
+        s_props.batteryStatus = android::BATTERY_STATUS_CHARGING;
+    else if(!strncmp((char *)status, "Discharging", 11))
+        s_props.batteryStatus = android::BATTERY_STATUS_DISCHARGING;
+    else if(!strncmp((char *)status, "Not charging", 12))
+        s_props.batteryStatus = android::BATTERY_STATUS_NOT_CHARGING;
+    else if(!strncmp((char *)status, "Full", 4))
+        s_props.batteryStatus = android::BATTERY_STATUS_FULL;
+}
+
+static void update_battery_health(struct monitor_pkt *mpkt)
+{
+    if ((mpkt->charge_full == 0) || (mpkt->charge_full_design == 0)) {
+        s_props.batteryHealth = android::BATTERY_HEALTH_DEAD;
+    }
+    else if ((((mpkt->charge_full)*100)/mpkt->charge_full_design) >= 80) {
+        s_props.batteryHealth = android::BATTERY_HEALTH_GOOD;
+    }
+    else
+        s_props.batteryHealth = android::BATTERY_HEALTH_UNKNOWN;
+}
+
+static void parse_battery_health(uint8_t *health)
+{
+    if(!strncmp((char *)health, "Unknown", 7))
+        s_props.batteryHealth = android::BATTERY_HEALTH_UNKNOWN;
+    else if(!strncmp((char *)health, "Good", 4))
+        s_props.batteryHealth = android::BATTERY_HEALTH_GOOD;
+    else if(!strncmp((char *)health, "Overheat", 8))
+        s_props.batteryHealth = android::BATTERY_HEALTH_OVERHEAT;
+    else if(!strncmp((char *)health, "Dead", 4))
+        s_props.batteryHealth = android::BATTERY_HEALTH_DEAD;
+    else if(!strncmp((char *)health, "Over voltage", 12))
+        s_props.batteryHealth = android::BATTERY_HEALTH_OVER_VOLTAGE;
+    else if(!strncmp((char *)health, "Unspecified failure", 18))
+        s_props.batteryHealth = android::BATTERY_HEALTH_UNSPECIFIED_FAILURE;
+    else if(!strncmp((char *)health, "Cold", 4))
+        s_props.batteryHealth = android::BATTERY_HEALTH_COLD;
+}
+
+static void parse_battery_type(uint8_t *type)
+{
+    if (!strncmp((char *)type, "Mains", 7))
+        s_props.chargerAcOnline = true;
+    else if (!strncmp((char *)type, "USB", 3))
+        s_props.chargerUsbOnline = true;
+}
+
+static void parse_init_properties(struct initial_pkt *ipkt)
+{
+    s_props.batteryTechnology = (char *)ipkt->technology;
+    s_props.batteryPresent = (strncmp((char *)ipkt->present, "1", 1) == 0);
+    parse_battery_type(ipkt->type);
+}
+
+static void parse_battery_properties(struct monitor_pkt *mpkt)
+{
+    s_props.batteryLevel = mpkt->capacity;
+    s_props.batteryVoltage = mpkt->voltage_now;
+    s_props.batteryTemperature = mpkt->temp;
+    s_props.batteryFullCharge = mpkt->charge_full;
+    s_props.batteryChargeCounter = mpkt->charge_now;
+    parse_battery_status(mpkt->status);
+    if (strlen((const char*)mpkt->health) == 0 ) {
+	    update_battery_health(mpkt);
+    }
+    else {
+	    parse_battery_health(mpkt->health);
+    }
+}
+
+static int connect_vsock(int *vsock_fd) {
+    struct sockaddr_vm sa = {
+        .svm_family = AF_VSOCK,
+        .svm_cid = VMADDR_CID_HOST,
+        .svm_port = HEALTH_PORT,
+    };
+    *vsock_fd = socket(AF_VSOCK, SOCK_STREAM, 0);
+    if (*vsock_fd < 0) {
+        KLOG_WARNING(HLOG_TAG, "healthd socket init failed\n");
+        return *vsock_fd;
+    }
+    if (connect(*vsock_fd, (struct sockaddr*)&sa, sizeof(sa)) != 0) {
+            KLOG_WARNING(HLOG_TAG, "healthd connect failed\n");
+            close(*vsock_fd);
+	    return -1;
+    }
+    KLOG_INFO(HLOG_TAG, "healthd connect to cid(%d) port(%d)\n", sa.svm_cid, sa.svm_port);
+    return 0;
+}
+
+static void recv_vsock() {
+    char msgbuf[1024];
+    int vsock_fd;
+    struct header *head;
+    struct monitor_pkt *mpkt;
+    struct initial_pkt *ipkt;
+
+    klog_set_level(KLOG_LEVEL);
+    head = (struct header *)malloc(sizeof(struct header));
+    if (!head)
+        goto exit;
+    mpkt = (struct monitor_pkt *)malloc(sizeof(struct monitor_pkt));
+    if (!mpkt)
+        goto free_head;
+    ipkt = (struct initial_pkt *)malloc(sizeof(struct initial_pkt));
+    if (!ipkt)
+        goto free_mpkt;
+    if (connect_vsock(&vsock_fd) == 0)
+        is_vsock_present = true;
+    while (is_vsock_present && errno != EBADF) {
+        int ret;
+        memset(msgbuf, 0, sizeof(msgbuf));
+        ret =  recv(vsock_fd, msgbuf, sizeof(msgbuf), MSG_DONTWAIT);
+        if (ret > 0) {
+            memcpy(head, msgbuf, sizeof(struct header));
+            if (head->notify_id == 1) {
+                memcpy(ipkt, msgbuf + sizeof(struct header), sizeof(struct initial_pkt));
+                parse_init_properties(ipkt);
+                memcpy(mpkt, msgbuf + sizeof(struct header) + sizeof (struct initial_pkt),
+                                                              sizeof(struct monitor_pkt));
+                parse_battery_properties(mpkt);
+            } else if (head->notify_id == 2) {
+                memcpy(mpkt, msgbuf + sizeof(struct header), sizeof(struct monitor_pkt));
+                parse_battery_properties(mpkt);
+            }
+        }
+        sleep(1);
+    }
+    free(ipkt);
+free_mpkt:
+    free(mpkt);
+free_head:
+    free(head);
+exit:
+    KLOG_INFO(HLOG_TAG, "Exiting healthd recv loop...\n");
+}
+
+void healthd_board_init(struct healthd_config *config)
+{
+    config->periodic_chores_interval_fast = 60;
+    config->periodic_chores_interval_slow = 60*10;
+
+    vsock_thread = std::thread(recv_vsock);
+    vsock_thread.detach();
+}
+
+int healthd_board_battery_update(struct android::BatteryProperties *props)
+{
+    // When batterylevel is 0, host OS would have shutdown.
+    if (s_props.batteryLevel != 0) {
+        memcpy(props, &s_props, sizeof(struct android::BatteryProperties));
+    } else {
+	props->batteryStatus = android::BATTERY_STATUS_UNKNOWN;
+	props->batteryHealth = android::BATTERY_HEALTH_UNKNOWN;
+	props->batteryLevel = 0;
+	props->batteryPresent= false;
+	props->chargerAcOnline = true;
+    }	    
+    return 0;
+}
+
+bool get_battery_mediation_present(void) {
+    return is_vsock_present;
+}
+

--- a/health/aidl/main.cpp
+++ b/health/aidl/main.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <android-base/logging.h>
+#include <android/binder_interface_utils.h>
+#include <health-impl/Health.h>
+#include <health/utils.h>
+
+#ifndef CHARGER_FORCE_NO_UI
+#define CHARGER_FORCE_NO_UI 0
+#endif
+
+#if !CHARGER_FORCE_NO_UI
+#include <health-impl/ChargerUtils.h>
+#endif
+
+using aidl::android::hardware::health::HalHealthLoop;
+using aidl::android::hardware::health::Health;
+
+#if !CHARGER_FORCE_NO_UI
+using aidl::android::hardware::health::charger::ChargerCallback;
+using aidl::android::hardware::health::charger::ChargerModeMain;
+#endif
+
+static constexpr const char* gInstanceName = "default";
+static constexpr std::string_view gChargerArg{"--charger"};
+
+int main(int argc, char** argv) {
+#ifdef __ANDROID_RECOVERY__
+    android::base::InitLogging(argv, android::base::KernelLogger);
+#endif
+
+    // make a default health service
+    auto config = std::make_unique<healthd_config>();
+    ::android::hardware::health::InitHealthdConfig(config.get());
+    auto binder = ndk::SharedRefBase::make<Health>(gInstanceName, std::move(config));
+
+    if (argc >= 2 && argv[1] == gChargerArg) {
+#if !CHARGER_FORCE_NO_UI
+        // If charger shouldn't have UI for your device, simply drop the line below
+        // for your service implementation. This corresponds to
+        // ro.charger.no_ui=true
+        return ChargerModeMain(binder, std::make_shared<ChargerCallback>(binder));
+#endif
+
+        LOG(INFO) << "Starting charger mode without UI.";
+    } else {
+        LOG(INFO) << "Starting health HAL.";
+    }
+
+    auto hal_health_loop = std::make_shared<HalHealthLoop>(binder, binder);
+    return hal_health_loop->StartLoop();
+}

--- a/health/aidl/main.cpp
+++ b/health/aidl/main.cpp
@@ -46,6 +46,7 @@ int main(int argc, char** argv) {
     // make a default health service
     auto config = std::make_unique<healthd_config>();
     ::android::hardware::health::InitHealthdConfig(config.get());
+    healthd_board_init(config.get());
     auto binder = ndk::SharedRefBase::make<Health>(gInstanceName, std::move(config));
 
     if (argc >= 2 && argv[1] == gChargerArg) {

--- a/health/aidl/utils/libhealthloop/Android.bp
+++ b/health/aidl/utils/libhealthloop/Android.bp
@@ -1,0 +1,35 @@
+// Copyright (C) 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+cc_library_static {
+    name: "libhealthloop-aidl.intel",
+    vendor_available: true,
+    recovery_available: true,
+    srcs: [
+        "HealthLoop.cpp",
+        "utils.cpp",
+    ],
+    shared_libs: [
+        "libcutils",
+        "libbase",
+    ],
+    header_libs: [
+        "libbatteryservice_headers",
+        "libhealthd_headers",
+        "libutils_headers",
+    ],
+    export_include_dirs: [
+        "include",
+    ],
+}

--- a/health/aidl/utils/libhealthloop/HealthLoop.cpp
+++ b/health/aidl/utils/libhealthloop/HealthLoop.cpp
@@ -1,0 +1,270 @@
+/*
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define LOG_TAG "HealthLoop"
+#define KLOG_LEVEL 6
+
+#include <health/HealthLoop.h>
+
+#include <errno.h>
+#include <libgen.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/epoll.h>
+#include <sys/timerfd.h>
+#include <unistd.h>
+
+#include <android-base/logging.h>
+#include <batteryservice/BatteryService.h>
+#include <cutils/klog.h>
+#include <cutils/uevent.h>
+#include <healthd/healthd.h>
+#include <utils/Errors.h>
+
+#include <health/utils.h>
+
+using namespace android;
+using namespace std::chrono_literals;
+
+#define POWER_SUPPLY_SUBSYSTEM "power_supply"
+
+namespace android {
+namespace hardware {
+namespace health {
+
+HealthLoop::HealthLoop() {
+    InitHealthdConfig(&healthd_config_);
+    awake_poll_interval_ = -1;
+    wakealarm_wake_interval_ = healthd_config_.periodic_chores_interval_fast;
+}
+
+HealthLoop::~HealthLoop() {
+    LOG(FATAL) << "HealthLoop cannot be destroyed";
+}
+
+int HealthLoop::RegisterEvent(int fd, BoundFunction func, EventWakeup wakeup) {
+    CHECK(!reject_event_register_);
+
+    auto* event_handler =
+            event_handlers_
+                    .emplace_back(std::make_unique<EventHandler>(EventHandler{this, fd, func}))
+                    .get();
+
+    struct epoll_event ev;
+
+    ev.events = EPOLLIN;
+
+    if (wakeup == EVENT_WAKEUP_FD) ev.events |= EPOLLWAKEUP;
+
+    ev.data.ptr = reinterpret_cast<void*>(event_handler);
+
+    if (epoll_ctl(epollfd_, EPOLL_CTL_ADD, fd, &ev) == -1) {
+        KLOG_ERROR(LOG_TAG, "epoll_ctl failed; errno=%d\n", errno);
+        return -1;
+    }
+
+    return 0;
+}
+
+void HealthLoop::WakeAlarmSetInterval(int interval) {
+    struct itimerspec itval;
+
+    if (wakealarm_fd_ == -1) return;
+
+    wakealarm_wake_interval_ = interval;
+
+    if (interval == -1) interval = 0;
+
+    itval.it_interval.tv_sec = interval;
+    itval.it_interval.tv_nsec = 0;
+    itval.it_value.tv_sec = interval;
+    itval.it_value.tv_nsec = 0;
+
+    if (timerfd_settime(wakealarm_fd_, 0, &itval, NULL) == -1)
+        KLOG_ERROR(LOG_TAG, "wakealarm_set_interval: timerfd_settime failed\n");
+}
+
+void HealthLoop::AdjustWakealarmPeriods(bool charger_online) {
+    // Fast wake interval when on charger (watch for overheat);
+    // slow wake interval when on battery (watch for drained battery).
+
+    int new_wake_interval = charger_online ? healthd_config_.periodic_chores_interval_fast
+                                           : healthd_config_.periodic_chores_interval_slow;
+
+    if (new_wake_interval != wakealarm_wake_interval_) WakeAlarmSetInterval(new_wake_interval);
+
+    // During awake periods poll at fast rate.  If wake alarm is set at fast
+    // rate then just use the alarm; if wake alarm is set at slow rate then
+    // poll at fast rate while awake and let alarm wake up at slow rate when
+    // asleep.
+
+    if (healthd_config_.periodic_chores_interval_fast == -1)
+        awake_poll_interval_ = -1;
+    else
+        awake_poll_interval_ = new_wake_interval == healthd_config_.periodic_chores_interval_fast
+                                       ? -1
+                                       : healthd_config_.periodic_chores_interval_fast * 1000;
+}
+
+void HealthLoop::PeriodicChores() {
+    ScheduleBatteryUpdate();
+}
+
+// TODO(b/140330870): Use BPF instead.
+#define UEVENT_MSG_LEN 2048
+void HealthLoop::UeventEvent(uint32_t /*epevents*/) {
+    // No need to lock because uevent_fd_ is guaranteed to be initialized.
+
+    char msg[UEVENT_MSG_LEN + 2];
+    char* cp;
+    int n;
+
+    n = uevent_kernel_multicast_recv(uevent_fd_, msg, UEVENT_MSG_LEN);
+    if (n <= 0) return;
+    if (n >= UEVENT_MSG_LEN) /* overflow -- discard */
+        return;
+
+    msg[n] = '\0';
+    msg[n + 1] = '\0';
+    cp = msg;
+
+    while (*cp) {
+        if (!strcmp(cp, "SUBSYSTEM=" POWER_SUPPLY_SUBSYSTEM)) {
+            ScheduleBatteryUpdate();
+            break;
+        }
+
+        /* advance to after the next \0 */
+        while (*cp++)
+            ;
+    }
+}
+
+void HealthLoop::UeventInit(void) {
+    uevent_fd_.reset(uevent_open_socket(64 * 1024, true));
+
+    if (uevent_fd_ < 0) {
+        KLOG_ERROR(LOG_TAG, "uevent_init: uevent_open_socket failed\n");
+        return;
+    }
+
+    fcntl(uevent_fd_, F_SETFL, O_NONBLOCK);
+    if (RegisterEvent(uevent_fd_, &HealthLoop::UeventEvent, EVENT_WAKEUP_FD))
+        KLOG_ERROR(LOG_TAG, "register for uevent events failed\n");
+}
+
+void HealthLoop::WakeAlarmEvent(uint32_t /*epevents*/) {
+    // No need to lock because wakealarm_fd_ is guaranteed to be initialized.
+
+    unsigned long long wakeups;
+
+    if (read(wakealarm_fd_, &wakeups, sizeof(wakeups)) == -1) {
+        KLOG_ERROR(LOG_TAG, "wakealarm_event: read wakealarm fd failed\n");
+        return;
+    }
+
+    PeriodicChores();
+}
+
+void HealthLoop::WakeAlarmInit(void) {
+    wakealarm_fd_.reset(timerfd_create(CLOCK_BOOTTIME_ALARM, TFD_NONBLOCK));
+    if (wakealarm_fd_ == -1) {
+        KLOG_ERROR(LOG_TAG, "wakealarm_init: timerfd_create failed\n");
+        return;
+    }
+
+    if (RegisterEvent(wakealarm_fd_, &HealthLoop::WakeAlarmEvent, EVENT_WAKEUP_FD))
+        KLOG_ERROR(LOG_TAG, "Registration of wakealarm event failed\n");
+
+    WakeAlarmSetInterval(healthd_config_.periodic_chores_interval_fast);
+}
+
+void HealthLoop::MainLoop(void) {
+    int nevents = 0;
+    while (1) {
+        reject_event_register_ = true;
+        size_t eventct = event_handlers_.size();
+        struct epoll_event events[eventct];
+        int timeout = awake_poll_interval_;
+
+        int mode_timeout;
+
+        /* Don't wait for first timer timeout to run periodic chores */
+        if (!nevents) PeriodicChores();
+
+        Heartbeat();
+
+        mode_timeout = PrepareToWait();
+        if (timeout < 0 || (mode_timeout > 0 && mode_timeout < timeout)) timeout = mode_timeout;
+        nevents = epoll_wait(epollfd_, events, eventct, timeout);
+        if (nevents == -1) {
+            if (errno == EINTR) continue;
+            KLOG_ERROR(LOG_TAG, "healthd_mainloop: epoll_wait failed\n");
+            break;
+        }
+
+        for (int n = 0; n < nevents; ++n) {
+            if (events[n].data.ptr) {
+                auto* event_handler = reinterpret_cast<EventHandler*>(events[n].data.ptr);
+                event_handler->func(event_handler->object, events[n].events);
+            }
+        }
+    }
+
+    return;
+}
+
+int HealthLoop::InitInternal() {
+    KLOG_INFO(LOG_TAG, "%s called...\n", __func__);
+    epollfd_.reset(epoll_create1(EPOLL_CLOEXEC));
+    if (epollfd_ == -1) {
+        KLOG_ERROR(LOG_TAG, "epoll_create1 failed; errno=%d\n", errno);
+        return -1;
+    }
+
+    // Call subclass's init for any additional init steps.
+    // Note that healthd_config_ is initialized before wakealarm_fd_; see
+    // AdjustUeventWakealarmPeriods().
+    Init(&healthd_config_);
+    healthd_config_.periodic_chores_interval_fast = 60;
+    healthd_config_.periodic_chores_interval_slow = 60*10; 
+    WakeAlarmInit();
+    UeventInit();
+
+    return 0;
+}
+
+int HealthLoop::StartLoop() {
+    int ret;
+
+    klog_set_level(KLOG_LEVEL);
+    KLOG_INFO(LOG_TAG, "%s called...\n", __func__);
+
+    ret = InitInternal();
+    if (ret) {
+        KLOG_ERROR(LOG_TAG, "Initialization failed, exiting\n");
+        return 2;
+    }
+
+    MainLoop();
+    KLOG_ERROR(LOG_TAG, "Main loop terminated, exiting\n");
+    return 3;
+}
+
+}  // namespace health
+}  // namespace hardware
+}  // namespace android

--- a/health/aidl/utils/libhealthloop/include/health/HealthLoop.h
+++ b/health/aidl/utils/libhealthloop/include/health/HealthLoop.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include <android-base/unique_fd.h>
+#include <healthd/healthd.h>
+
+namespace android {
+namespace hardware {
+namespace health {
+
+class HealthLoop {
+  public:
+    HealthLoop();
+
+    // Client is responsible for holding this forever. Process will exit
+    // when this is destroyed.
+    virtual ~HealthLoop();
+
+    // Initialize and start the main loop. This function does not exit unless
+    // the process is interrupted.
+    // Once the loop is started, event handlers are no longer allowed to be
+    // registered.
+    int StartLoop();
+
+  protected:
+    // healthd_mode_ops overrides. Note that healthd_mode_ops->battery_update
+    // is missing because it is only used by BatteryMonitor.
+    // Init is called right after epollfd_ is initialized (so RegisterEvent
+    // is allowed) but before other things are initialized (so SetChargerOnline
+    // is not allowed.)
+    virtual void Init(healthd_config* config) = 0;
+    virtual void Heartbeat() = 0;
+    virtual int PrepareToWait() = 0;
+
+    // Note that this is NOT healthd_mode_ops->battery_update(BatteryProperties*),
+    // which is called by BatteryMonitor after values are fetched. This is the
+    // implementation of healthd_battery_update(), which calls
+    // the correct IHealth::update(),
+    // which calls BatteryMonitor::update(), which calls
+    // healthd_mode_ops->battery_update(BatteryProperties*).
+    virtual void ScheduleBatteryUpdate() = 0;
+
+    // Register an epoll event. When there is an event, |func| will be
+    // called with |this| as the first argument and |epevents| as the second.
+    // This may be called in a different thread from where StartLoop is called
+    // (for obvious reasons; StartLoop never ends).
+    // Once the loop is started, event handlers are no longer allowed to be
+    // registered.
+    using BoundFunction = std::function<void(HealthLoop*, uint32_t /* epevents */)>;
+    int RegisterEvent(int fd, BoundFunction func, EventWakeup wakeup);
+
+    // Helper for implementing ScheduleBatteryUpdate(). An implementation of
+    // ScheduleBatteryUpdate should get charger_online from BatteryMonitor::update(),
+    // then reset wake alarm interval by calling AdjustWakealarmPeriods.
+    void AdjustWakealarmPeriods(bool charger_online);
+
+  private:
+    struct EventHandler {
+        HealthLoop* object = nullptr;
+        int fd;
+        BoundFunction func;
+    };
+
+    int InitInternal();
+    void MainLoop();
+    void WakeAlarmInit();
+    void WakeAlarmEvent(uint32_t);
+    void UeventInit();
+    void UeventEvent(uint32_t);
+    void WakeAlarmSetInterval(int interval);
+    void PeriodicChores();
+
+    // These are fixed after InitInternal() is called.
+    struct healthd_config healthd_config_;
+    android::base::unique_fd wakealarm_fd_;
+    android::base::unique_fd uevent_fd_;
+
+    android::base::unique_fd epollfd_;
+    std::vector<std::unique_ptr<EventHandler>> event_handlers_;
+    int awake_poll_interval_;  // -1 for no epoll timeout
+    int wakealarm_wake_interval_;
+
+    // If set to true, future RegisterEvent() will be rejected. This is to ensure all
+    // events are registered before StartLoop().
+    bool reject_event_register_ = false;
+};
+
+}  // namespace health
+}  // namespace hardware
+}  // namespace android

--- a/health/aidl/utils/libhealthloop/include/health/utils.h
+++ b/health/aidl/utils/libhealthloop/include/health/utils.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <healthd/healthd.h>
+
+namespace android {
+namespace hardware {
+namespace health {
+
+void InitHealthdConfig(struct healthd_config* healthd_config);
+
+}  // namespace health
+}  // namespace hardware
+}  // namespace android

--- a/health/aidl/utils/libhealthloop/utils.cpp
+++ b/health/aidl/utils/libhealthloop/utils.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <health/utils.h>
+namespace android {
+namespace hardware {
+namespace health {
+
+// Periodic chores fast interval in seconds
+#define DEFAULT_PERIODIC_CHORES_INTERVAL_FAST (60 * 1)
+// Periodic chores fast interval in seconds
+#define DEFAULT_PERIODIC_CHORES_INTERVAL_SLOW (60 * 10)
+
+void InitHealthdConfig(struct healthd_config* healthd_config) {
+    *healthd_config = {
+            .periodic_chores_interval_fast = DEFAULT_PERIODIC_CHORES_INTERVAL_FAST,
+            .periodic_chores_interval_slow = DEFAULT_PERIODIC_CHORES_INTERVAL_SLOW,
+            .energyCounter = NULL,
+            .boot_min_cap = 0,
+            .screen_on = NULL,
+    };
+}
+
+}  // namespace health
+}  // namespace hardware
+}  // namespace android


### PR DESCRIPTION
Error in reading Battery percentage of host in guest VM

[Change Details]:
 -upgrading from health@2.1 to health@aidl hal.
 -vsock connection between the guest and the batsys host.
  Therefore, Intel libhealthd-aidl.intel was added to the
  static library.
 -For health services, Intel healthloop is required by
  Health HAL.The AOSP health service itself is sufficient
  in spite of this dependency. consequently, customized
  healthloop-aidl.intel was added to the static library.

[Test Details]:
 -enable batsys entry "battery_med=/home/intel/ww48/scripts/batsys"
  in ini file.
 -launch Android.
 -can check battery mediation data in guest using
  "adb shell dumpsys battery".
 -can also check using UI path settings->battery.

[Additional Details]:
 -most of changes are made in health.cpp,main.cpp and
  health-convert.cpp
 -heath packages is customized from
  android.hardware.health-service.example
  to android.hardware.health-service.intel

Tracked-On: OAM-105769
Signed-off-by: Rajani Ranjan <rajani.ranjan@intel.com>
