### PR TITLE
handle battery capacity level beyond 100%.

### DIFF
--- a/health/aidl/libhealthd/healthd_board_default.cpp
+++ b/health/aidl/libhealthd/healthd_board_default.cpp
@@ -184,7 +184,8 @@ void healthd_board_init(struct healthd_config *config)
 int healthd_board_battery_update(struct android::BatteryProperties *props)
 {
     // When batterylevel is 0, host OS would have shutdown.
-    if (s_props.batteryLevel != 0) {
+    // When batterylevel is more than 100, host OS is corrupted.
+    if (0 <= s_props.batteryLevel && s_props.batteryLevel <= 100) {
         memcpy(props, &s_props, sizeof(struct android::BatteryProperties));
     } else {
 	props->batteryStatus = android::BATTERY_STATUS_UNKNOWN;


### PR DESCRIPTION
set battery default values when host capacity level reaches percentage beyond 100%

Tracked-On: OAM-108660