### PR TITLE
changes in battery level to fix multicamera recording issue.

### DIFF
--- a/health/aidl/libhealthd/healthd_board_default.cpp
+++ b/health/aidl/libhealthd/healthd_board_default.cpp
@@ -185,7 +185,7 @@ int healthd_board_battery_update(struct android::BatteryProperties *props)
 {
     // When batterylevel is 0, host OS would have shutdown.
     // When batterylevel is more than 100, host OS is corrupted.
-    if (0 <= s_props.batteryLevel && s_props.batteryLevel <= 100) {
+    if (0 < s_props.batteryLevel && s_props.batteryLevel <= 100) {
         memcpy(props, &s_props, sizeof(struct android::BatteryProperties));
     } else {
 	props->batteryStatus = android::BATTERY_STATUS_UNKNOWN;


### PR DESCRIPTION
changes in battery level to fix multicamera recording issue.

if battery mediation is not present then by default battery capacity
is set to 0. As a result multicamera was going in screen lock mode
when left ideal for 1 to 2 minutes.

Tracked-On: OAM-109713
Signed-off-by: Ranjan, Rajani <rajani.ranjan@intel.com>