### PR TITLE
Added BAD_VALUE mSensors.size() is zero

### DIFF
--- a/sensors/2.0/iiohal_mediation_v2.0/Sensors.h
+++ b/sensors/2.0/iiohal_mediation_v2.0/Sensors.h
@@ -98,6 +98,9 @@ struct Sensors : public ISensorsInterface, public ISensorsEventCallback {
     }
 
     Return<Result> setOperationMode(OperationMode mode) override {
+	if(mSensors.size() <= 0) {
+            return Result::BAD_VALUE;
+	}
         for (auto& sensor : mSensors) {
             sensor.second->setOperationMode(mode);
         }


### PR DESCRIPTION
For celadon added BAD_VALUE mSensors.size() is zero Fix for VtsHalSensorsV2_0TargetTest

Tracked-On: OAM-111163