### PR TITLE
bootctrl: Update to AIDL implementation

### DIFF
--- a/boot/Android.bp
+++ b/boot/Android.bp
@@ -1,25 +1,60 @@
-cc_library_shared {
-    name: "android.hardware.boot@1.2-impl-intel",
-    stem: "android.hardware.boot@1.0-impl-1.2-intel",
+//
+// Copyright (C) 2022 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 
+//package {
+    // See: http://go/android-license-faq
+    // A large-scale-change added 'default_applicable_licenses' to import
+    // all of the 'license_kinds' from "hardware_interfaces_license"
+    // to get the below license kinds:
+    //   SPDX-license-identifier-Apache-2.0
+    //default_applicable_licenses: ["hardware_interfaces_license"],
+//}
+
+cc_defaults {
+    name: "android.hardware.boot-service",
     relative_install_path: "hw",
-    vendor: true,
-    recovery_available: true,
-    srcs: ["BootControl.cpp"],
-
+    defaults: ["libboot_control_defaults"],
+    vintf_fragments: ["android.hardware.boot-service.xml"],
     shared_libs: [
-        "liblog",
-        "libhidlbase",
+        "libbase",
+        "libbinder_ndk",
         "libhardware",
         "libutils",
-        "android.hardware.boot@1.0",
         "android.hardware.boot@1.1",
-        "android.hardware.boot@1.2",
+        "android.hardware.boot-V1-ndk",
     ],
     static_libs: [
-        "libfstab",
+        "libboot_control",
     ],
     include_dirs: [
         "hardware/intel/bootctrl",
     ],
+    srcs: ["main.cpp", "BootControl.cpp"],
+}
+
+cc_binary {
+    name: "android.hardware.boot-service.intel",
+    defaults: ["android.hardware.boot-service"],
+    init_rc: ["android.hardware.boot-service.rc"],
+    vendor: true,
+}
+
+cc_binary {
+    name: "android.hardware.boot-service.recovery",
+    defaults: ["android.hardware.boot-service"],
+    init_rc: ["android.hardware.boot-service.recovery.rc"],
+    recovery: true,
 }

--- a/boot/BootControl.h
+++ b/boot/BootControl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 The Android Open Source Project
+ * Copyright (C) 2022 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,50 +16,33 @@
 
 #pragma once
 
-#include <android/hardware/boot/1.2/IBootControl.h>
-#include <hidl/MQDescriptor.h>
-#include <hidl/Status.h>
+#include <aidl/android/hardware/boot/BnBootControl.h>
+#include <libboot_control/libboot_control.h>
+#include <hardware/boot_control.h>
 
-namespace android {
-namespace hardware {
-namespace boot {
-namespace V1_2 {
-namespace implementation {
-using ::android::hardware::Return;
-using ::android::hardware::Void;
-using ::android::hardware::boot::V1_0::BoolResult;
-using ::android::hardware::boot::V1_1::MergeStatus;
-using ::android::hardware::boot::V1_2::IBootControl;
+using ndk::ScopedAStatus;
 
-class BootControl : public IBootControl {
+namespace aidl::android::hardware::boot {
+
+class BootControl final : public BnBootControl {
   public:
-    explicit BootControl(boot_control_module_t *module);
-
-    // Methods from ::android::hardware::boot::V1_0::IBootControl.
-    Return<uint32_t> getNumberSlots() override;
-    Return<uint32_t> getCurrentSlot() override;
-    Return<void> markBootSuccessful(markBootSuccessful_cb _hidl_cb) override;
-    Return<void> setActiveBootSlot(uint32_t slot, setActiveBootSlot_cb _hidl_cb) override;
-    Return<void> setSlotAsUnbootable(uint32_t slot, setSlotAsUnbootable_cb _hidl_cb) override;
-    Return<BoolResult> isSlotBootable(uint32_t slot) override;
-    Return<BoolResult> isSlotMarkedSuccessful(uint32_t slot) override;
-    Return<void> getSuffix(uint32_t slot, getSuffix_cb _hidl_cb) override;
-
-    // Methods from ::android::hardware::boot::V1_1::IBootControl.
-    Return<bool> setSnapshotMergeStatus(MergeStatus status) override;
-    Return<MergeStatus> getSnapshotMergeStatus() override;
-
-    // Methods from ::android::hardware::boot::V1_2::IBootControl.
-    Return<uint32_t> getActiveBootSlot() override;
+    BootControl();
+    ScopedAStatus getActiveBootSlot(int32_t* _aidl_return) override;
+    ScopedAStatus getCurrentSlot(int32_t* _aidl_return) override;
+    ScopedAStatus getNumberSlots(int32_t* _aidl_return) override;
+    ScopedAStatus getSnapshotMergeStatus(
+        ::aidl::android::hardware::boot::MergeStatus* _aidl_return) override;
+    ScopedAStatus getSuffix(int32_t in_slot, std::string* _aidl_return) override;
+    ScopedAStatus isSlotBootable(int32_t in_slot, bool* _aidl_return) override;
+    ScopedAStatus isSlotMarkedSuccessful(int32_t in_slot, bool* _aidl_return) override;
+    ScopedAStatus markBootSuccessful() override;
+    ScopedAStatus setActiveBootSlot(int32_t in_slot) override;
+    ScopedAStatus setSlotAsUnbootable(int32_t in_slot) override;
+    ScopedAStatus setSnapshotMergeStatus(
+        ::aidl::android::hardware::boot::MergeStatus in_status) override;
 
   private:
     boot_control_module_t *mModule;
 };
 
-extern "C" IBootControl* HIDL_FETCH_IBootControl(const char* name);
-
-}  // namespace implementation
-}  // namespace V1_2
-}  // namespace boot
-}  // namespace hardware
-}  // namespace android
+}  // namespace aidl::android::hardware::boot

--- a/boot/android.hardware.boot-service.rc
+++ b/boot/android.hardware.boot-service.rc
@@ -1,0 +1,4 @@
+service vendor.boot-default /vendor/bin/hw/android.hardware.boot-service.intel
+    class early_hal
+    user root
+    group root

--- a/boot/android.hardware.boot-service.recovery.rc
+++ b/boot/android.hardware.boot-service.recovery.rc
@@ -1,0 +1,6 @@
+service vendor.boot-default /system/bin/hw/android.hardware.boot-service.recovery
+    class early_hal
+    user root
+    group root
+    interface aidl android.hardware.boot.IBootControl/default
+

--- a/boot/android.hardware.boot-service.xml
+++ b/boot/android.hardware.boot-service.xml
@@ -1,0 +1,6 @@
+<manifest version="1.0" type="device">
+    <hal format="aidl">
+        <name>android.hardware.boot</name>
+        <fqname>IBootControl/default</fqname>
+    </hal>
+</manifest>

--- a/boot/main.cpp
+++ b/boot/main.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "BootControl.h"
+
+#include <android-base/logging.h>
+#include <android/binder_manager.h>
+#include <android/binder_process.h>
+
+using aidl::android::hardware::boot::BootControl;
+using aidl::android::hardware::boot::IBootControl;
+
+int main(int, char* argv[]) {
+    android::base::InitLogging(argv, android::base::KernelLogger);
+    ABinderProcess_setThreadPoolMaxThreadCount(0);
+    std::shared_ptr<IBootControl> service = ndk::SharedRefBase::make<BootControl>();
+
+    const std::string instance = std::string(BootControl::descriptor) + "/default";
+    auto status = AServiceManager_addService(service->asBinder().get(), instance.c_str());
+    CHECK_EQ(status, STATUS_OK) << "Failed to add service " << instance << " " << status;
+    LOG(INFO) << "IBootControl AIDL service running...";
+
+    ABinderProcess_joinThreadPool();
+    return EXIT_FAILURE;  // should not reach
+}


### PR DESCRIPTION
The minimum requirement for Boot HAL in android 14 should be AIDL implementation to meet target-level 8, API level 34 requirement.

Tracked-On: OAM-112811