### PR TITLE
Fix static analysis issue for health module

### DIFF
--- a/health/2.1/libhealthd/battery_notifypkt.h
+++ b/health/2.1/libhealthd/battery_notifypkt.h
@@ -19,7 +19,7 @@ struct initial_pkt {
     uint8_t model_name[28];
     uint8_t serial_number[52];
     uint8_t manufacturer[24];
-    uint8_t technology[8];
+    uint8_t technology[9];
     uint8_t type[8];
     uint8_t present[4];
 };
@@ -36,7 +36,7 @@ struct monitor_pkt {
     uint8_t charge_type[12];
     uint8_t capacity_level[12];
     uint8_t status[12];
-    uint8_t health[24];
+    uint8_t health[25];
 };
 
 /* TODO Below structure is not getting used in this version of code.

--- a/health/2.1/libhealthd/healthd_board_default.cpp
+++ b/health/2.1/libhealthd/healthd_board_default.cpp
@@ -86,6 +86,7 @@ static void parse_battery_type(uint8_t *type)
 
 static void parse_init_properties(struct initial_pkt *ipkt)
 {
+    ipkt->technology[8]='\0';
     s_props.batteryTechnology = (char *)ipkt->technology;
     s_props.batteryPresent = (strncmp((char *)ipkt->present, "1", 1) == 0);
     parse_battery_type(ipkt->type);
@@ -99,6 +100,7 @@ static void parse_battery_properties(struct monitor_pkt *mpkt)
     s_props.batteryFullCharge = mpkt->charge_full;
     s_props.batteryChargeCounter = mpkt->charge_now;
     parse_battery_status(mpkt->status);
+    mpkt->health[24]='\0';
     if (strcmp((const char*)mpkt->health,"\0") == 0)
         update_battery_health(mpkt);
     else


### PR DESCRIPTION
String not null terminated issue is resolved.

mpkt->health and ipkt->technology are string which required null terminator to solve memory leak issue

Tracked-On: OAM-116767