### PR TITLE
Fix cts test case "testSensorAdditionalInfo"

### DIFF
--- a/sensors/2.0/Android.bp
+++ b/sensors/2.0/Android.bp
@@ -24,7 +24,7 @@ soong_config_module_type {
 senPlugin_cc_defaults {
     name: "senPlugin_defaults",
     soong_config_variables: {
-        SENSOR_LIST: { cflags: ["-DSENSOR_LIST_ENABLED"],},
+        SENSOR_LIST: { cflags: ["-DSENSOR_LIST_ENABLED","-DFEATURE_AUTOMOTIVE"]},
     },
 }
 

--- a/sensors/2.0/iiohal_mediation_v2.0/Sensors.h
+++ b/sensors/2.0/iiohal_mediation_v2.0/Sensors.h
@@ -65,9 +65,11 @@ struct Sensors : public ISensorsInterface, public ISensorsEventCallback {
           mAutoReleaseWakeLockTime(0),
           mHasWakeLock(false) {
 #if SENSOR_LIST_ENABLED
+#ifndef FEATURE_AUTOMOTIVE
         AddSensor<AccelSensor>();
         AddSensor<GyroSensor>();
         AddSensor<MagnetometerSensor>();
+#endif
         AddSensor<LightSensor>();
         AddSensor<GravitySensor>();
         AddSensor<RotationVector>();

--- a/sensors/aidl/Android.bp
+++ b/sensors/aidl/Android.bp
@@ -25,7 +25,7 @@ soong_config_module_type {
 senPlugin_cc_default {
     name: "senPlugin_default",
     soong_config_variables: {
-        SENSOR_LIST: { cflags: ["-DSENSOR_LIST_ENABLED"],},
+        SENSOR_LIST: { cflags: ["-DSENSOR_LIST_ENABLED","-DFEATURE_AUTOMOTIVE"]},
     },
 }
 

--- a/sensors/aidl/include/sensors-impl/Sensors.h
+++ b/sensors/aidl/include/sensors-impl/Sensors.h
@@ -46,9 +46,11 @@ class Sensors : public BnSensors, public ISensorsEventCallback {
           mAutoReleaseWakeLockTime(0),
           mHasWakeLock(false) {
 #if SENSOR_LIST_ENABLED
+#ifndef FEATURE_AUTOMOTIVE
         AddSensor<AccelSensor>();
         AddSensor<GyroSensor>();
         AddSensor<MagnetometerSensor>();
+#endif
         AddSensor<LightSensor>();
         AddSensor<GravitySensor>();
         AddSensor<RotationVector>();


### PR DESCRIPTION
Addition sensor info should not be supported on automotive sersor, include accelerometer, Gyroscope, Magnetic, add macro to disable them.

Test: run cts -m CtsSensorTestCases -t
android.hardware.cts.SensorAdditionalInfoTest#testSensorAdditionalInfo

Tracked-On: OAM-117803