### PR TITLE
Use android.hardware.sensors-V2-ndk for sensors@aidl version_2

### DIFF
--- a/sensors/aidl/Android.bp
+++ b/sensors/aidl/Android.bp
@@ -37,7 +37,7 @@ cc_library_static {
         "libfmq",
         "libpower",
         "libbinder_ndk",
-        "android.hardware.sensors-V1-ndk",
+        "android.hardware.sensors-V2-ndk",
     ],
     export_include_dirs: ["include"],
     srcs: [
@@ -74,7 +74,7 @@ cc_library_static {
         "libfmq",
         "libpower",
         "libbinder_ndk",
-        "android.hardware.sensors-V1-ndk",
+        "android.hardware.sensors-V2-ndk",
         "liblog",
         "libdl",
         "libxml2",
@@ -107,7 +107,7 @@ cc_binary {
         "libcutils",
         "liblog",
         "libutils",
-        "android.hardware.sensors-V1-ndk",
+        "android.hardware.sensors-V2-ndk",
         "libxml2",
     ],
     static_libs: [


### PR DESCRIPTION
Should not use android.hardware.sensors-V1-ndk for sensors@aidl version_2 to avoid vts failure.

Test Done:
run vts -m vts_treble_vintf_vendor_test
-t DeviceManifest/SingleAidlTest#HalIsServed/android_hardware_sensors_ISensors_default_V2_18

Tracked-On: OAM-118511