### PR TITLE
Update health VINTF fragment to version 2

### DIFF
--- a/health/aidl/android.hardware.health-service.intel.xml
+++ b/health/aidl/android.hardware.health-service.intel.xml
@@ -1,7 +1,7 @@
 <manifest version="1.0" type="device">
     <hal format="aidl">
         <name>android.hardware.health</name>
-        <version>1</version>
+        <version>2</version>
         <fqname>IHealth/default</fqname>
     </hal>
 </manifest>


### PR DESCRIPTION
The actual version of health interface used is 2, so update the manifest.

Test Done:
run vts -m vts_treble_vintf_vendor_test

Tracked-On: OAM-118554