### PR TITLE
Added BAD_VALUE mSensors.size() is zero

### DIFF
--- a/sensors/aidl/Sensors.cpp
+++ b/sensors/aidl/Sensors.cpp
@@ -141,7 +141,10 @@ ScopedAStatus Sensors::registerDirectChannel(const ISensors::SharedMemInfo& /* i
 }
 
 ScopedAStatus Sensors::setOperationMode(OperationMode in_mode) {
-    for (auto sensor : mSensors) {
+	if(mSensors.size() <= 0) {
+            return ScopedAStatus::fromServiceSpecificError(static_cast<int32_t>(ERROR_BAD_VALUE));
+        }
+    	for (auto sensor : mSensors) {
         sensor.second->setOperationMode(in_mode);
     }
     return ScopedAStatus::ok();


### PR DESCRIPTION
For celadon Return BAD_VALUE, when sensors size is zero Fix for VtsHalSensorsV2_0TargetTest

Tracked-On: OAM-118440