### PR TITLE
Fix ATS sensors issues for base_aaos

### DIFF
--- a/sensors/aidl/Sensor.cpp
+++ b/sensors/aidl/Sensor.cpp
@@ -189,6 +189,7 @@ std::vector<Event> Sensor::readEvents() {
                 event.payload.set<EventPayload::Tag::data>(data);
                 break;
             }
+            case SensorType::ACCELEROMETER_UNCALIBRATED:
             case SensorType::GYROSCOPE_UNCALIBRATED: {
                 uncal = {
                     .x = iioc->devlist[mSensorInfo.sensorHandle].data[0],
@@ -213,7 +214,7 @@ std::vector<Event> Sensor::readEvents() {
             case SensorType::ACCELEROMETER_LIMITED_AXES:
             case SensorType::GYROSCOPE_LIMITED_AXES: {
             Event::EventPayload::LimitedAxesImu limitedAxesImu;
-                limitedAxesImu ={
+                limitedAxesImu = {
                     .x = iioc->devlist[mSensorInfo.sensorHandle].data[0],
                     .y = iioc->devlist[mSensorInfo.sensorHandle].data[1],
                     .z = iioc->devlist[mSensorInfo.sensorHandle].data[2],
@@ -322,8 +323,19 @@ std::vector<Event> Sensor::readEvents() {
                 event.payload.set<EventPayload::Tag::data>(data);
                 break;
             }
+            case SensorType::ACCELEROMETER_UNCALIBRATED: {
+                uncal = {
+                    .x = 0,
+                    .y = 0,
+                    .z = 9.8,
+                    .xBias = 0,
+                    .yBias = 0,
+                    .zBias = 0};
+                event.payload.set<EventPayload::Tag::uncal>(uncal);
+                break;
+            }
             case SensorType::GYROSCOPE_UNCALIBRATED: {
-                uncal={
+                uncal = {
                     .x = -0.009562,
                     .y = -0.002142,
                     .z = -0.174638,
@@ -364,7 +376,7 @@ std::vector<Event> Sensor::readEvents() {
             case SensorType::ACCELEROMETER_LIMITED_AXES:
             case SensorType::GYROSCOPE_LIMITED_AXES: {
             Event::EventPayload::LimitedAxesImu limitedAxesImu;
-                limitedAxesImu ={
+                limitedAxesImu = {
                     .x = 0,
                     .y = 0,
                     .z = 0,
@@ -576,6 +588,25 @@ AccelSensor::AccelSensor(int32_t sensorHandle, ISensorsEventCallback* callback) 
     #endif
 
 }
+
+AccelSensor_uncalibrated::AccelSensor_uncalibrated(int32_t sensorHandle, ISensorsEventCallback* callback) : Sensor(callback) {
+    mSensorInfo.sensorHandle = sensorHandle;
+    mSensorInfo.name = "Accel Sensor uncalibrated";
+    mSensorInfo.vendor = "Intel";
+    mSensorInfo.version = 1;
+    mSensorInfo.type = SensorType::ACCELEROMETER_UNCALIBRATED;
+    mSensorInfo.typeAsString = "";
+    mSensorInfo.maxRange = 78.4f;  // +/- 8g
+    mSensorInfo.resolution = 1.52e-5;
+    mSensorInfo.power = 0.001f;        // mA
+    mSensorInfo.minDelayUs = 10 * 1000;  // microseconds
+    mSensorInfo.maxDelayUs = 10 * 1000 * 10;  // microseconds
+    mSensorInfo.fifoReservedEventCount = 0;
+    mSensorInfo.fifoMaxEventCount = 0;
+    mSensorInfo.requiredPermission = "";
+    mSensorInfo.flags = static_cast<uint32_t>(SensorInfo::SENSOR_FLAG_BITS_DATA_INJECTION);
+}
+
 PressureSensor::PressureSensor(int32_t sensorHandle, ISensorsEventCallback* callback)
     : Sensor(callback) {
     mSensorInfo.sensorHandle = sensorHandle;
@@ -679,6 +710,24 @@ GyroSensor::GyroSensor(int32_t sensorHandle, ISensorsEventCallback* callback) : 
     #elif
     mSensorInfo.flags = static_cast<uint32_t>(SensorInfo::SENSOR_FLAG_BITS_DATA_INJECTION);
     #endif
+}
+
+GyroSensor_uncalibrated::GyroSensor_uncalibrated(int32_t sensorHandle, ISensorsEventCallback* callback) : Sensor(callback) {
+    mSensorInfo.sensorHandle = sensorHandle;
+    mSensorInfo.name = "GyroSensor_uncalibrated";
+    mSensorInfo.vendor = "Intel";
+    mSensorInfo.version = 1;
+    mSensorInfo.type = SensorType::GYROSCOPE_UNCALIBRATED;
+    mSensorInfo.typeAsString = "";
+    mSensorInfo.maxRange = 1000.0f * M_PI / 180.0f;
+    mSensorInfo.resolution = 1000.0f * M_PI / (180.0f * 32768.0f);
+    mSensorInfo.power = 0.001f;
+    mSensorInfo.minDelayUs = 10 * 1000;  // microseconds
+    mSensorInfo.maxDelayUs = 10 * 1000 * 10;  // microseconds
+    mSensorInfo.fifoReservedEventCount = 0;
+    mSensorInfo.fifoMaxEventCount = 0;
+    mSensorInfo.requiredPermission = "";
+    mSensorInfo.flags = static_cast<uint32_t>(SensorInfo::SENSOR_FLAG_BITS_DATA_INJECTION);
 }
 
 AmbientTempSensor::AmbientTempSensor(int32_t sensorHandle, ISensorsEventCallback* callback)

--- a/sensors/aidl/iioClient.cpp
+++ b/sensors/aidl/iioClient.cpp
@@ -30,7 +30,7 @@ iioClient *iioClient::iioc = NULL;
  * name@sensor_map should be matched with iio sensor name and returns sensor-id.
  * Where stuct iio_sensor_map -> {name, id};
  */
-struct iio_sensor_map sensor_map[10] = {
+struct iio_sensor_map sensor_map[12] = {
     {"unknown", 0},
     {"accel_3d", 1},
     {"gyro_3d", 2},
@@ -41,6 +41,8 @@ struct iio_sensor_map sensor_map[10] = {
     {"geomagnetic_orientation", 7},
     {"relative_orientation", 8},
     {"incli_3d", 9},
+    {"AccelSensor_uncalibrated", 10},
+    {"GyroSensor_uncalibrated", 11},
 };
 
 /**

--- a/sensors/aidl/iioClient.h
+++ b/sensors/aidl/iioClient.h
@@ -36,7 +36,7 @@
 
 #include "libiio_client/iio.h"
 
-#define MAX_SENSOR 9
+#define MAX_SENSOR 11
 #define MAX_CHANNEL 3
 #define SENSOR_PORT "30431"
 #define USE_VM_CONTEXT

--- a/sensors/aidl/include/sensors-impl/Sensor.h
+++ b/sensors/aidl/include/sensors-impl/Sensor.h
@@ -116,9 +116,19 @@ class AccelSensor : public Sensor {
     AccelSensor(int32_t sensorHandle, ISensorsEventCallback* callback);
 };
 
+class AccelSensor_uncalibrated : public Sensor {
+  public:
+    AccelSensor_uncalibrated(int32_t sensorHandle, ISensorsEventCallback* callback);
+};
+
 class GyroSensor : public Sensor {
   public:
     GyroSensor(int32_t sensorHandle, ISensorsEventCallback* callback);
+};
+
+class GyroSensor_uncalibrated : public Sensor {
+  public:
+    GyroSensor_uncalibrated(int32_t sensorHandle, ISensorsEventCallback* callback);
 };
 
 class AmbientTempSensor : public OnChangeSensor {

--- a/sensors/aidl/include/sensors-impl/Sensors.h
+++ b/sensors/aidl/include/sensors-impl/Sensors.h
@@ -56,6 +56,10 @@ class Sensors : public BnSensors, public ISensorsEventCallback {
         AddSensor<GeomagnaticRotationVector>();
         AddSensor<OrientationSensor>();
         AddSensor<InclinometerSensor>();
+#ifndef FEATURE_AUTOMOTIVE
+        AddSensor<AccelSensor_uncalibrated>();
+        AddSensor<GyroSensor_uncalibrated>();
+#endif
 #endif  
     }
 


### PR DESCRIPTION
ATS test cases were failing for uncalibrated sensors. 

1.testTypeAccelerometerUncalibrated
2.testTypeGyroscopeUnCalibrated

Test Done:
run cts -m AtsSensorsDeviceTests

Tracked-On: OAM-118805