### PR TITLE
Remove compass sensor from sensor list

### DIFF
--- a/sensors/aidl/include/sensors-impl/Sensors.h
+++ b/sensors/aidl/include/sensors-impl/Sensors.h
@@ -49,7 +49,6 @@ class Sensors : public BnSensors, public ISensorsEventCallback {
 #if SENSOR_LIST_ENABLED
         AddSensor<AccelSensor>();
         AddSensor<GyroSensor>();
-        AddSensor<MagnetometerSensor>();
         AddSensor<LightSensor>();
         AddSensor<GravitySensor>();
         AddSensor<RotationVector>();


### PR DESCRIPTION
Remove compass sensor from sensor list as system has no actual sensor, cts test case testSensorOperations_magneticField will assert the sensor.

Tracked-On: OAM-121832