### PR TITLE
Disable wakeup while polling for netlink event

### DIFF
--- a/health/2.0/healthd_common.cpp
+++ b/health/2.0/healthd_common.cpp
@@ -97,8 +97,6 @@ int healthd_register_event(int fd, void (*handler)(uint32_t), EventWakeup wakeup
 
     ev.events = EPOLLIN;
 
-    if (wakeup == EVENT_WAKEUP_FD) ev.events |= EPOLLWAKEUP;
-
     ev.data.ptr = (void*)handler;
     if (epoll_ctl(epollfd, EPOLL_CTL_ADD, fd, &ev) == -1) {
         KLOG_ERROR(LOG_TAG, "epoll_ctl failed; errno=%d\n", errno);

--- a/health/2.1/utils/libhealthloop/HealthLoop.cpp
+++ b/health/2.1/utils/libhealthloop/HealthLoop.cpp
@@ -68,8 +68,6 @@ int HealthLoop::RegisterEvent(int fd, BoundFunction func, EventWakeup wakeup) {
 
     ev.events = EPOLLIN;
 
-    if (wakeup == EVENT_WAKEUP_FD) ev.events |= EPOLLWAKEUP;
-
     ev.data.ptr = reinterpret_cast<void*>(event_handler);
 
     if (epoll_ctl(epollfd_, EPOLL_CTL_ADD, fd, &ev) == -1) {

--- a/health/aidl/utils/libhealthloop/HealthLoop.cpp
+++ b/health/aidl/utils/libhealthloop/HealthLoop.cpp
@@ -68,8 +68,6 @@ int HealthLoop::RegisterEvent(int fd, BoundFunction func, EventWakeup wakeup) {
 
     ev.events = EPOLLIN;
 
-    if (wakeup == EVENT_WAKEUP_FD) ev.events |= EPOLLWAKEUP;
-
     ev.data.ptr = reinterpret_cast<void*>(event_handler);
 
     if (epoll_ctl(epollfd_, EPOLL_CTL_ADD, fd, &ev) == -1) {


### PR DESCRIPTION
Suspend fails in baremetal due to polling for
netlink event.
This Patch is to disable wakeup while polling for
netlink event.

Tracked-On: OAM-123276