### PR TITLE
Coverity fixes for ExternalCamera and RemoteCamera

### DIFF
--- a/camera/device/default/ExternalCameraDeviceSession.cpp
+++ b/camera/device/default/ExternalCameraDeviceSession.cpp
@@ -798,6 +798,7 @@ Status ExternalCameraDeviceSession::switchToOffline(
                     native_handle_t* handle = native_handle_create(/*numFds*/ 1, /*numInts*/ 0);
                     handle->data[0] = buffer.acquireFence;
                     outputBuffer.releaseFence = android::makeToAidl(handle);
+                    native_handle_delete(handle);
                 }
             } else {
                 offlineBuffers.push_back(buffer);
@@ -1781,6 +1782,7 @@ Status ExternalCameraDeviceSession::processCaptureRequestError(
             native_handle_t* handle = native_handle_create(/*numFds*/ 1, /*numInts*/ 0);
             handle->data[0] = req->buffers[i].acquireFence;
             result.outputBuffers[i].releaseFence = ::android::makeToAidl(handle);
+            native_handle_delete(handle);
         }
     }
 
@@ -1827,6 +1829,7 @@ Status ExternalCameraDeviceSession::processCaptureResult(std::shared_ptr<HalRequ
                 native_handle_t* handle = native_handle_create(/*numFds*/ 1, /*numInts*/ 0);
                 handle->data[0] = req->buffers[i].acquireFence;
                 result.outputBuffers[i].releaseFence = ::android::makeToAidl(handle);
+                native_handle_delete(handle);
             }
             notifyError(req->frameNumber, req->buffers[i].streamId, ErrorCode::ERROR_BUFFER);
         } else {
@@ -1836,6 +1839,7 @@ Status ExternalCameraDeviceSession::processCaptureResult(std::shared_ptr<HalRequ
                 native_handle_t* handle = native_handle_create(/*numFds*/ 1, /*numInts*/ 0);
                 handle->data[0] = req->buffers[i].acquireFence;
                 result.outputBuffers[i].releaseFence = ::android::makeToAidl(handle);
+                native_handle_delete(handle);
             }
         }
     }

--- a/camera/device/default/ExternalCameraOfflineSession.cpp
+++ b/camera/device/default/ExternalCameraOfflineSession.cpp
@@ -111,6 +111,7 @@ Status ExternalCameraOfflineSession::processCaptureResult(std::shared_ptr<HalReq
                 native_handle_t* handle = native_handle_create(/*numFds*/ 1, /*numInts*/ 0);
                 handle->data[0] = req->buffers[i].acquireFence;
                 result.outputBuffers[i].releaseFence = android::makeToAidl(handle);
+                native_handle_delete(handle);
             }
             notifyError(req->frameNumber, req->buffers[i].streamId, ErrorCode::ERROR_BUFFER);
         } else {
@@ -120,6 +121,7 @@ Status ExternalCameraOfflineSession::processCaptureResult(std::shared_ptr<HalReq
                 native_handle_t* handle = native_handle_create(/*numFds*/ 1, /*numInts*/ 0);
                 handle->data[0] = req->buffers[i].acquireFence;
                 outputBuffer.releaseFence = android::makeToAidl(handle);
+                native_handle_delete(handle);
             }
         }
     }
@@ -248,6 +250,7 @@ Status ExternalCameraOfflineSession::processCaptureRequestError(
             native_handle_t* handle = native_handle_create(/*numFds*/ 1, /*numInts*/ 0);
             handle->data[0] = req->buffers[i].acquireFence;
             outputBuffer.releaseFence = makeToAidl(handle);
+            native_handle_delete(handle);
         }
     }
 


### PR DESCRIPTION
Addressed high priority coverity issues related to resource leaks, string not-null termination etc.

Tests done:

1. Flashed the image with fixes
2. Open AOSP camera and Multicamera app
3. Able to capture and record with both apps

Tracked-On: OAM-122344