### PR TITLE
Fixing uninitialized variable coverity issue

### DIFF
--- a/bluetooth/bluetooth_hci.cc
+++ b/bluetooth/bluetooth_hci.cc
@@ -33,7 +33,7 @@ static const uint8_t HCI_DATA_TYPE_SCO = 3;
 
 class BluetoothDeathRecipient : public hidl_death_recipient {
  public:
-  BluetoothDeathRecipient(const sp<IBluetoothHci> hci) : mHci(hci) {}
+  BluetoothDeathRecipient(const sp<IBluetoothHci> hci) : mHci(hci), has_died_(false) {}
 
   virtual void serviceDied(
       uint64_t /*cookie*/,


### PR DESCRIPTION
has_died_ is not initialized in this constructor nor in any functions that it calls

Initialized has_died_ in constructor

Tested:
BT on/off
Connect phone, play music
HFP call
File transfer
CtsBluetoothTestCases

Tracked-On: OAM-123193