### PR TITLE
Fix VTS loopback issue in bt hal

### DIFF
--- a/bluetooth/h4_protocol.cc
+++ b/bluetooth/h4_protocol.cc
@@ -40,6 +40,7 @@
 #define INTEL_PID_9560 0x0aaa // 9460/9560 also know as Jefferson Peak (JfP)
 #define INTEL_PID_AX201 0x0026 // AX201 also know as Harrison Peak (HrP)
 #define INTEL_PID_AX211 0x0033 // AX211 also know as GarfieldPeak (Gfp)
+#define INTEL_PID_AX210 0x0032 // AX210 also know as TyphoonPeak (TyP2)
 
 #include <errno.h>
 #include <fcntl.h>
@@ -88,7 +89,8 @@ bool H4Protocol::IsIntelController(uint16_t vid, uint16_t pid) {
                                 (pid == INTEL_PID_9260)||
                                 (pid == INTEL_PID_9560)||
                                 (pid == INTEL_PID_AX201)||
-                                (pid == INTEL_PID_AX211)))
+                                (pid == INTEL_PID_AX211)||
+                                (pid == INTEL_PID_AX210)))
         return true;
     else
 	return false;


### PR DESCRIPTION
During local loopback mode, Intel controller were not sending the HCI number of completed packets for ACL transactions. But as per the Google VTS its mandatory to send this HCI NOCP event from controller.

Send this NOCP HCI event from BT HAL to for ACL transcations during local loopback mode to pass VTS test cases.

Revert this patch when we have BT FW from core team supporting NOCP.

Tests done:
1. Boot Android
2. run vts -m VtsHalBluetoothV1_0Target
3. All test cases passed
4. adb reboot
5. Check BT on/off success
6. A2DP, HFP success
7. FTP success

Tracked-On: OAM-122967