### PR TITLE
Fix VTS loopback issue in bt hal

### DIFF
--- a/bluetooth/aidl/default/BluetoothHci.h
+++ b/bluetooth/aidl/default/BluetoothHci.h
@@ -53,6 +53,10 @@ class BluetoothHci : public BnBluetoothHci {
 
   static BluetoothHci* get();
 
+  void sendNOCPHciEvent(const std::vector<uint8_t>& packet);
+
+  void checkLocalLoopbackCmd(const std::vector<uint8_t>& packet);
+
  private:
   int mFd{-1};
   std::shared_ptr<IBluetoothHciCallbacks> mCb = nullptr;
@@ -82,6 +86,7 @@ class BluetoothHci : public BnBluetoothHci {
     ONE_CLIENT,
     CLOSING,
   } mState{HalState::READY};
+  bool isLocalLoopbackActive;
 };
 
 }  // namespace aidl::android::hardware::bluetooth::impl

--- a/bluetooth/hci/hci_internals.h
+++ b/bluetooth/hci/hci_internals.h
@@ -52,4 +52,6 @@ static constexpr size_t kIsoLengthOffset = 2;
 
 static constexpr size_t kMaxHeaderSize = kAclHeaderSize;
 
+static const uint16_t HCI_WRITE_LOCAL_LOOPBACK_OPCODE = 0x1802;
+
 }  // namespace android::hardware::bluetooth::hci


### PR DESCRIPTION
During local loopback mode, Intel controller were not sending the HCI number of completed packets for ACL transactions. But as per the Google VTS its mandatory to send this HCI NOCP event from controller.

Send this NOCP HCI event from BT HAL to for ACL transcations during local loopback mode to pass VTS test cases.

Revert this patch when we have BT FW from core team supporting NOCP.

Tests done:
1. Boot Android
2. run vts -m VtsHalBluetoothTargetTest
3. All test cases passed
4. adb reboot
5. Check BT on/off success
6. A2DP, HFP success
7. FTP success

Tracked-On: OAM-128387