### PR TITLE
Fix evs one camera preview crop

### DIFF
--- a/evs/apps/default/res/config.json
+++ b/evs/apps/default/res/config.json
@@ -71,7 +71,7 @@
       "hflip" : false,
       "vflip" : false,
       "width": 1920,
-      "height": 1536
+      "height": 1080
     },
     {
       "cameraId" : "/dev/video3",


### PR DESCRIPTION
Added the supported resolution for the
required evs app camera

Tests-done:
- Android boot successful
- Evs app launch successful
- 4 cameras display seen

Tracked-On: OAM-128603