### PR TITLE
Fix copy instead of move coverity issues

### DIFF
--- a/bluetooth/h4_protocol.h
+++ b/bluetooth/h4_protocol.h
@@ -33,9 +33,9 @@ class H4Protocol : public HciProtocol {
   H4Protocol(int fd, PacketReadCallback event_cb, PacketReadCallback acl_cb,
              PacketReadCallback sco_cb)
       : uart_fd_(fd),
-        event_cb_(event_cb),
-        acl_cb_(acl_cb),
-        sco_cb_(sco_cb),
+        event_cb_(std::move(event_cb)),
+        acl_cb_(std::move(acl_cb)),
+        sco_cb_(std::move(sco_cb)),
         hci_packetizer_([this]() { OnPacketReady(); }) {}
 
   size_t Send(uint8_t type, const uint8_t* data, size_t length);

--- a/bluetooth/hci_packetizer.h
+++ b/bluetooth/hci_packetizer.h
@@ -33,7 +33,7 @@ using HciPacketReadyCallback = std::function<void(void)>;
 class HciPacketizer {
  public:
   HciPacketizer(HciPacketReadyCallback packet_cb)
-      : packet_ready_cb_(packet_cb){};
+      : packet_ready_cb_(std::move(packet_cb)){};
   void OnDataReady(int fd, HciPacketType packet_type);
   void CbHciPacket(uint8_t* data, size_t length);
   const hidl_vec<uint8_t>& GetPacket() const;

--- a/bluetooth/mct_protocol.cc
+++ b/bluetooth/mct_protocol.cc
@@ -30,8 +30,8 @@ namespace hci {
 
 MctProtocol::MctProtocol(int* fds, PacketReadCallback event_cb,
                          PacketReadCallback acl_cb)
-    : event_cb_(event_cb),
-      acl_cb_(acl_cb),
+    : event_cb_(std::move(event_cb)),
+      acl_cb_(std::move(acl_cb)),
       event_packetizer_([this]() { OnEventPacketReady(); }),
       acl_packetizer_([this]() { OnAclDataPacketReady(); }) {
   for (int i = 0; i < CH_MAX; i++) {


### PR DESCRIPTION
Fix COPY_INSTEAD_OF_MOVE which impacts performance inefficiencies in bt hal. Copy is costlier than move operation in c++. As all the callbacks are getting simply assigned to new callbacks, its safer to user std::move inplace of copy constructor which eats up more time and memory.

References:
https://en.cppreference.com/w/cpp/utility/move
https://stackoverflow.com/questions/36827900/what-makes-moving-objects-faster-than-copying

Tests done:
1. BT on/off -> 20times
2. Connect phone, play music -> 10 times
3. HFP call -> 10 times
4. File transfer
5. CtsBluetoothTestCases - pass

Tracked-On: OAM-129099