### PR TITLE
fix VTS issue related to sensors operation mode.

### DIFF
--- a/sensors/aidl/Sensors.cpp
+++ b/sensors/aidl/Sensors.cpp
@@ -144,6 +144,15 @@ ScopedAStatus Sensors::setOperationMode(OperationMode in_mode) {
     for (auto sensor : mSensors) {
         sensor.second->setOperationMode(in_mode);
     }
+
+    //In case of no sensors
+    std::vector<SensorInfo> sensorInfoList;
+    getSensorsList(&sensorInfoList);
+    if (sensorInfoList.size() == 0) {
+        ALOGD("sensors list is empty");
+    return ScopedAStatus::fromExceptionCode(EX_UNSUPPORTED_OPERATION);
+    }
+
     return ScopedAStatus::ok();
 }
 


### PR DESCRIPTION
fix VTS issue related to sensors operation mode.

Test Run :
-SetOperationMode/0_android_hardware_sensors_ISensors_default

Test Done:
run vts -m VtsAidlHalSensorsTargetTest

Result: passed

Tracked-On: OAM-129484
Signed-off-by: Rajani Ranjan <rajani.ranjan@intel.com>