### PR TITLE
BSP_DIFF cleanup

### DIFF
--- a/health/aidl/Android.bp
+++ b/health/aidl/Android.bp
@@ -20,7 +20,7 @@ cc_defaults {
         "libcutils",
         "liblog",
         "libutils",
-        "android.hardware.health-V2-ndk",
+        "android.hardware.health-V3-ndk",
 
         // TODO(b/177269435): remove when BatteryMonitor works with AIDL HealthInfo.
         "libhidlbase",
@@ -39,7 +39,7 @@ cc_defaults {
     name: "libhealth_aidl_charger_defaults.intel",
     shared_libs: [
         // common
-        "android.hardware.health-V2-ndk",
+        "android.hardware.health-V3-ndk",
         "libbase",
         "libcutils",
         "liblog",

--- a/health/aidl/utils/libhealthloop/include/health/HealthLoop.h
+++ b/health/aidl/utils/libhealthloop/include/health/HealthLoop.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <vector>

--- a/sensors/aidl/libiio_client/xml.c
+++ b/sensors/aidl/libiio_client/xml.c
@@ -21,6 +21,7 @@
 
 #include <errno.h>
 #include <libxml/tree.h>
+#include <libxml/parser.h>
 #include <string.h>
 
 static int add_attr_to_channel(struct iio_channel *chn, xmlNode *n)


### PR DESCRIPTION
Facing build errors due to older hal version and due to undeclared apis using older c99 ISO formats.

Tests done: EB is booted sucessfully.

Tracked-On: OAM-127806