### PR TITLE
Fix antutu image process score low

### DIFF
--- a/graphic/dgpu-renderwlocal.cfg
+++ b/graphic/dgpu-renderwlocal.cfg
@@ -2,3 +2,5 @@
 k.auto:refinery
 k.auto:transfer
 android.vending
+mark.auto:video
+.fisheye


### PR DESCRIPTION
When run antutu, find image process score becoming much lower than before. Add missing proc name for image process.

Tracked-On: OAM-130002