### PR TITLE
Add the config file for dgpu render with local memory

### DIFF
--- a/graphic/README
+++ b/graphic/README
@@ -1,0 +1,14 @@
+The script check-process-name.sh is used to detect the process name of app in Andorid.
+1. Get the IP and PORT or Serial Number of Android device.
+2. Run the script before open/run the Android app:
+   $ chmod +x check-process-name.sh
+   $ ./check-process-name.sh IP:PORT
+   or
+   $ ./check-process-name.sh Serial Number
+3. Run the Android app, after app complete or after a while, ctrl+ c to stop the sript.
+   The process names of app will print out.
+4. Add the process names to the dgpu-renderwlocal.cfg
+   then push to /vendor/etc/
+   $ adb push dgpu-renderwlocal.cfg /vendor/etc/
+   Or rebuild the Android image.
+The app will use dgpu render and local memory.

--- a/graphic/check-process-name.sh
+++ b/graphic/check-process-name.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+trap 'cleanup_and_exit' SIGINT
+
+cleanup_and_exit() {
+    echo -e "\nDetect Ctrl+C，clean up the temporary files..."
+    rm -f diff_process process_name after before
+    echo "Add the following process names to cfg file, excluding the system related process, like:
+    main, mapsplaceholder, system_server, ndroid.systemui, hardware.intel. etc."
+    cat add_process
+    echo -e "\n"
+    rm add_process
+    exit 0
+}
+
+# Check if a parameter is provided
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 <Device IP:PORT or Serial Number>"
+    exit 1
+fi
+
+device=$1
+
+if [ -f "$before" ]; then
+  rm -f "$before"
+fi
+
+if [ -f "$after" ]; then
+  rm -f "$after"
+fi
+
+if [ -f "$diff_process" ]; then
+  rm -f "$diff_process"
+fi
+
+if [ -f "$process_name" ]; then
+  rm -f "$process_name"
+fi
+
+if [ -f "$add_process" ]; then
+  rm -f "$add_process"
+fi
+
+# Determine if the input is an IP address or a device serial number
+if [[ $device =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+(:[0-9]+)?$ ]]; then
+    echo "Attempting to connect to network device: $device"
+    adb connect $device
+    adb -s $device root
+    adb connect $device
+else
+    echo "Attempting to connect to USB device: $device"
+    adb -s $device root
+fi
+
+if [ $? -ne 0 ]; then
+    echo "device connect fail, exit!"
+    exit 1
+fi
+
+echo -e "\nRun the Android app, after app complete or after a while, ctrl+ c to stop the sript.\nThe process names of app will print out."
+
+keywords=("main" "mapsplaceholder" "system_server" "ndroid.systemui" "hardware.intel." "car.carlauncher" "car.usb.handler" "id.car.settings")
+
+touch before
+touch after
+adb -s $device shell lsof /dev/dri/renderD128 > before
+touch diff_process
+touch process_name
+touch add_process
+while true; do
+    adb -s $device shell lsof /dev/dri/renderD128 > after
+    diff before after > diff_process
+    awk '{print $2}' diff_process | sort -u >process_name
+    while read -r line; do
+        match_found=false
+        for keyword in "${keywords[@]}"; do
+            if [[ "$line" == "$keyword"* ]]; then
+                match_found=true
+                break
+            fi
+        done
+
+        if [ "$match_found" = false ]; then
+            if ! grep -Fxq "$line" add_process; then
+                echo "$line" >> add_process
+            fi
+        fi
+    done < process_name
+
+    rm diff_process
+    touch diff_process
+    rm process_name
+    touch process_name
+    cp after before
+    rm after
+    touch after
+
+    sleep 2
+done

--- a/graphic/dgpu-renderwlocal.cfg
+++ b/graphic/dgpu-renderwlocal.cfg
@@ -1,0 +1,7 @@
+.benchmark.auto
+k.auto:refinery
+k.auto:transfer
+android.vending
+mark.auto:video
+.fisheye
+com.intel.lic


### PR DESCRIPTION
The dgpu-renderwlocal.cfg is used to save the process that need use dgpu render and local memory.

Tracked-On: OAM-130613