### PR TITLE
EVS App Suspend and Resume Enabled

### DIFF
--- a/evs/apps/default/inc/EvsStateControl.h
+++ b/evs/apps/default/inc/EvsStateControl.h
@@ -90,6 +90,7 @@ private:
     aidl::android::hardware::automotive::vehicle::VehiclePropValue mGearValue;
     aidl::android::hardware::automotive::vehicle::VehiclePropValue mTurnSignalValue;
 
+    aidl::android::hardware::automotive::vehicle::VehiclePropValue mPowerStateReport;
     State mCurrentState = OFF;
 
     // mCameraList is a redundant storage for camera device info, which is also
@@ -112,6 +113,8 @@ private:
     // True if the first frame displayed on the mCurrentRenderer. Resets to false when
     // mCurrentRenderer changes.
     bool mFirstFrameIsDisplayed;
+
+    bool mSuspend;
 };
 
 #endif  // CAR_EVS_APP_EVSSTATECONTROL_H

--- a/evs/apps/default/src/evs_app.cpp
+++ b/evs/apps/default/src/evs_app.cpp
@@ -254,6 +254,9 @@ int main(int argc, char** argv) {
             if (!subscribeToVHal(subscriptionClient.get(), VehicleProperty::TURN_SIGNAL_STATE)) {
                 LOG(WARNING) << "Didn't get turn signal notifications, so we'll ignore those.";
             }
+            if(!subscribeToVHal(subscriptionClient.get(), VehicleProperty::AP_POWER_STATE_REPORT)) {
+                LOG(ERROR) << "Subscription for AP Power State Report Failed";
+            }
         }
     } else {
         LOG(WARNING) << "Test mode selected, so not talking to Vehicle HAL";


### PR DESCRIPTION
Issue Detailed: On System Suspend, EVS App is not releasing the camera resources and evs display is getting struck, As Camera resources are not released the subsequent System Resume Session Cameras are not working and also display is acquired before the display is ready for changes

Issue Fixed:
1) Registered to Vehicle Property APPowerStateReport to Release the
   camera resources when state is changed to Suspend
2) Listen to the gear changes only when the APPowerState is ON 3) Release the Display Before Closing the Cameras to apply the closing
   of EVS app while entering suspend
4) After Resume Check if the displayinfo status is OK to ensure that
   display is in correct state to accept surface changes

Tested-On: EVS App is working fine with car service suspend and resume

Tracked-On: OAM-131926