### PR TITLE
Property Based FPS Logs Enable/Disable

### DIFF
--- a/evs/evsHal/aidl/include/VideoCapture.h
+++ b/evs/evsHal/aidl/include/VideoCapture.h
@@ -75,6 +75,8 @@ private:
     int mNumBuffers = 0;
     uint32_t mBufferSize;
 
+    static int mNumCamerasStreaming;
+
     std::unique_ptr<v4l2_buffer[]> mBufferInfos = nullptr;
     std::unique_ptr<void*[]> mPixelBuffers = nullptr;
 


### PR DESCRIPTION
Issue Detailed: FPS Calculcation and display logic is not present

Issue Fixed: Enable/Disable FPS calculation and print by setting property vendor.camera.fps.evs.dqbuf

Tested-On: FPS log printed by setting property

Tracked-On: OAM-131204