### PR TITLE
Add support for VirtVideo and UVCVideo Device Nodes

### DIFF
--- a/evs/apps/default/res/config.json
+++ b/evs/apps/default/res/config.json
@@ -26,8 +26,8 @@
   },
   "cameras" : [
     {
-      "cameraId" : "/dev/video0",
-      "function" : "reverse,park",
+      "cameraId" : "/dev/virtvideo0",
+      "function" : "reverse",
       "x" : 0.0,
       "y" : 20.0,
       "z" : 48,
@@ -42,8 +42,8 @@
       "height": 720
     },
     {
-      "cameraId" : "/dev/video1",
-      "function" : "front,park",
+      "cameraId" : "/dev/virtvideo1",
+      "function" : "front, reverse",
       "x" : 0.0,
       "y" : 100.0,
       "z" : 48,
@@ -58,8 +58,8 @@
       "height": 1080
     },
     {
-      "cameraId" : "/dev/video2",
-      "function" : "right,park",
+      "cameraId" : "/dev/virtvideo2",
+      "function" : "right,reverse",
       "x" : -25.0,
       "y" : 60.0,
       "z" : 88,
@@ -74,8 +74,8 @@
       "height": 1080
     },
     {
-      "cameraId" : "/dev/video3",
-      "function" : "left, park",
+      "cameraId" : "/dev/virtvideo3",
+      "function" : "left, reverse",
       "x" : 20.0,
       "y" : 60.0,
       "z" : 88,

--- a/evs/evsHal/aidl/resources/evs_configuration_intel_default.xml
+++ b/evs/evsHal/aidl/resources/evs_configuration_intel_default.xml
@@ -31,7 +31,7 @@
     <!-- camera device information -->
     <camera>
         <!-- camera device starts -->
-        <device id='/dev/video0' position='rear'>
+        <device id='/dev/virtvideo0' position='rear'>
             <caps>
                 <!-- list of supported controls -->
                 <supported_controls>
@@ -86,7 +86,7 @@
                 />
             </characteristics>
         </device>
-        <device id='/dev/video1' position='front'>
+        <device id='/dev/virtvideo1' position='front'>
             <caps>
                 <!-- list of supported controls -->
                 <supported_controls>
@@ -143,7 +143,7 @@
         </device>
 
         <!-- vivid emulated video devices -->
-        <device id='/dev/video2' position='right'>
+        <device id='/dev/virtvideo2' position='right'>
             <caps>
                 <!-- list of supported controls -->
                 <supported_controls>
@@ -160,7 +160,7 @@
             <!-- list of parameters -->
             <characteristics/>
         </device>
-        <device id='/dev/video3' position='left'>
+        <device id='/dev/virtvideo3' position='left'>
             <caps>
                 <!-- list of supported controls -->
                 <supported_controls>


### PR DESCRIPTION
EVS HAL Supporting only video devices and not enumerating virtvideo and uvcvideo devices

Added Support for virtvideo and uvcvideo devices

Tracked-On: OAM-132140