### PR TITLE
[vhal] Fix uninitialized scalar field issue by initializing

### DIFF
--- a/vehicle/Conn/VSpiComm/VSpiComm.cpp
+++ b/vehicle/Conn/VSpiComm/VSpiComm.cpp
@@ -35,7 +35,7 @@ namespace V2_0 {
 namespace impl {
 
 VSpiComm::VSpiComm(MessageProcessor* messageProcessor)
-    : CommConn(messageProcessor), mSpiDevice("/dev/spidev0.0"), mMode(SPI_MODE_0), mBitsPerWord(8), mSpeed(100000) {
+    : CommConn(messageProcessor), mSpiDevice("/dev/spidev0.0"), mMode(SPI_MODE_0), mBitsPerWord(8), mSpeed(100000), mSpiFd(-1) {
     // Constructor now only initializes member variables
 }
 


### PR DESCRIPTION
 mSpiFd in VSpiComm constructor

Tracked-On: OAM-132359