### PR TITLE
Fix Deadlock in EVSGLDisplay

### DIFF
--- a/evs/evsHal/aidl/src/EvsGlDisplay.cpp
+++ b/evs/evsHal/aidl/src/EvsGlDisplay.cpp
@@ -219,6 +219,7 @@ void EvsGlDisplay::renderFrames() {
             std::lock_guard lock(mLock);
             mBufferBusy = false;
         }
+        mBufferReadyToUse.notify_all();
         mBufferDone.notify_all();
     }
 


### PR DESCRIPTION
Deadlock observed in EVSGLDisplay Class due to condition variable notify not done when render buffer takes time

Added condition variable notify to check for the predicate changes to fix the unconditional wait and avoid deadlock of evs

Tracked-On: OAM-132673