### PR TITLE
Make gpu type for SF rendering selectable

### DIFF
--- a/graphic/dgpu-codec.cfg
+++ b/graphic/dgpu-codec.cfg
@@ -1,0 +1,3 @@
+vendor.video.hw.dgpu 0
+vendor.video.hw.output.linear 0
+vendor.render.hw.dgpu 0

--- a/graphic/dgpu-renderwlocal.cfg
+++ b/graphic/dgpu-renderwlocal.cfg
@@ -1,4 +1,4 @@
-surfaceflinger
+#surfaceflinger
 .benchmark.auto
 k.auto:refinery
 k.auto:transfer
@@ -10,3 +10,4 @@ m.webview_shell
 lla.firefox:gpu
 .qiyi.video.pad
 ileged_process0
+50005.corporate

--- a/graphic/dgpu-renderwlocal.cfg
+++ b/graphic/dgpu-renderwlocal.cfg
@@ -1,3 +1,4 @@
+surfaceflinger
 .benchmark.auto
 k.auto:refinery
 k.auto:transfer


### PR DESCRIPTION
Surfaceflinger will use dgpu by default in dual gpu cases.

Tracked-On: OAM-132135